### PR TITLE
Use enum for RPC method names - incomplete proof-of-concept for feedback.

### DIFF
--- a/bitcoinj-proxy/src/main/java/com/msgilligan/bitcoinj/proxy/RpcProxyHandler.java
+++ b/bitcoinj-proxy/src/main/java/com/msgilligan/bitcoinj/proxy/RpcProxyHandler.java
@@ -1,5 +1,6 @@
 package com.msgilligan.bitcoinj.proxy;
 
+import static com.msgilligan.bitcoinj.rpc.BitcoinClientMethod.*;
 import com.msgilligan.bitcoinj.rpc.JsonRpcRequest;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
@@ -7,8 +8,10 @@ import static ratpack.jackson.Jackson.fromJson;
 import ratpack.http.client.HttpClient;
 
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 
 /**
  * JsonRPC proxy handler
@@ -16,7 +19,9 @@ import java.util.List;
  * (defaults to localhost with regtest port)
  */
 public class RpcProxyHandler extends AbstractJsonRpcHandler implements Handler {
-    private final List<String> allowedMethods =  Arrays.asList("getblockcount", "setgenerate");
+    private final List<String> allowedMethods =
+            Stream.of(getblockcount, setgenerate)
+                .map(Enum::name).collect(Collectors.toList());
 
     protected RpcProxyHandler() throws URISyntaxException {
         super();

--- a/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/AbstractRPCClient.java
+++ b/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/AbstractRPCClient.java
@@ -135,4 +135,8 @@ public abstract class AbstractRPCClient implements UntypedRPCClient {
         return send(method, Arrays.asList(params));
     }
 
+    public <R> R send(JSONRPCMethod method, Object... params) throws IOException, JsonRPCStatusException {
+        return send(method.name(), Arrays.asList(params));
+    }
+
 }

--- a/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClient.java
+++ b/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClient.java
@@ -34,6 +34,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import static com.msgilligan.bitcoinj.rpc.BitcoinClientMethod.*;
 
 /**
  * = JSON-RPC Client for *Bitcoin Core*
@@ -238,7 +239,7 @@ public class BitcoinClient extends RPCClient implements NetworkParametersPropert
      * @return The current block count
      */
     public Integer getBlockCount() throws JsonRPCException, IOException {
-        return send("getblockcount");
+        return send(getblockcount);
     }
 
     /**
@@ -248,7 +249,7 @@ public class BitcoinClient extends RPCClient implements NetworkParametersPropert
      * @return The block hash
      */
     public Sha256Hash getBlockHash(Integer index) throws JsonRPCException, IOException {
-        return send("getblockhash", Sha256Hash.class, index);
+        return send(getblockhash, Sha256Hash.class, index);
     }
 
     /**
@@ -289,7 +290,7 @@ public class BitcoinClient extends RPCClient implements NetworkParametersPropert
      */
     public List<Sha256Hash> setGenerate(Boolean generate, Long genproclimit) throws JsonRPCException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, Sha256Hash.class);
-        return send("setgenerate", resultType, generate, genproclimit);
+        return send(setgenerate, resultType, generate, genproclimit);
     }
 
 
@@ -303,7 +304,7 @@ public class BitcoinClient extends RPCClient implements NetworkParametersPropert
     public List<Sha256Hash> generate(int numBlocks) throws IOException, JsonRPCException {
         if (getServerVersion() > 110000) {
             JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, Sha256Hash.class);
-            return send("generate", resultType, numBlocks);
+            return send(generate, resultType, numBlocks);
         } else {
             // For backward compatibility, to be removed eventually
             return setGenerate(true, (long) numBlocks);

--- a/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClientMethod.java
+++ b/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClientMethod.java
@@ -1,0 +1,12 @@
+package com.msgilligan.bitcoinj.rpc;
+
+/**
+ * Enumerated type of known Bitcoin RPC methods
+ */
+public enum BitcoinClientMethod implements JSONRPCMethod {
+        getblockcount,
+        getblockhash,
+        @Deprecated
+        setgenerate,
+        generate
+}

--- a/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/JSONRPCMethod.java
+++ b/bitcoinj-rpcclient/src/main/java/com/msgilligan/bitcoinj/rpc/JSONRPCMethod.java
@@ -1,0 +1,9 @@
+package com.msgilligan.bitcoinj.rpc;
+
+/**
+ *  Marker interface that must be implemented by enums that declare
+ *  known RPC method names
+ */
+public interface JSONRPCMethod {
+    String name();
+}


### PR DESCRIPTION
This pull request explores the possibility of using `enum` types for RPC methods. One or more `enum` types can be created, such as `BitcoinClientMethod.java` that defines method names as constants. This provides compile-time (and editor) checking for valid names. It also allows us to mark method names as `@Deprecated`.

This PR only implements a couple of names, but if it gets good feedback ( @dexX7 ) I can flesh it out a little more.
