### PR TITLE
WIP: Upgrade to AsciidoctorJ 1.5.7

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -45,7 +45,7 @@ allprojects {
 
     dependencies {
         asciidoclet "org.asciidoctor:asciidoclet:${asciidocletVersion}"
-        asciidoclet "org.asciidoctor:asciidoctorj:${asciidoctorjVersion}"
+        asciidoclet "org.asciidoctor:asciidoctorj:1.5.7"
         asciidoclet "org.asciidoctor:asciidoctorj-diagram:${asciidoctorjDiagramVersion}"
     }
 


### PR DESCRIPTION
Work-in-progress upgrade to AsciidoctorJ 1.5.7

AsciidoctorJ 1.5.7 is currently failing when used with Asciidoclet (at least in this project) 
See https://github.com/asciidoctor/asciidoclet/issues/45 for discussion.
