### PR TITLE
cj-nmc-daemon: Use libdohj Namecoin NetworkParameters.

### DIFF
--- a/cj-nmc-daemon/build.gradle
+++ b/cj-nmc-daemon/build.gradle
@@ -21,11 +21,13 @@ idea {
 
 repositories {
     mavenLocal()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
     compile project(':bitcoinj-server')
     compile "org.springframework.boot:spring-boot-starter-web"
+    implementation "com.github.dogecoin:libdohj:31fb8985ba13fbf20f102679df75fc7daf5098d4"
 }
 
 springBoot {

--- a/cj-nmc-daemon/src/main/java/org/consensusj/namecoin/daemon/config/NamecoinConfig.java
+++ b/cj-nmc-daemon/src/main/java/org/consensusj/namecoin/daemon/config/NamecoinConfig.java
@@ -8,7 +8,7 @@ import com.msgilligan.bitcoinj.spring.service.PeerGroupService;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscovery;
-import org.bitcoinj.params.MainNetParams;
+import org.libdohj.params.NamecoinMainNetParams;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,11 +21,10 @@ import java.io.FileNotFoundException;
 public class NamecoinConfig {
     @Bean
     public NetworkParameters networkParameters() {
-        // TODO: Replace this with Namecoin MainNet Params from libdohj
-        // We may also want to make this set from a configuration string
+        // TODO: We may also want to make this set from a configuration string
         // so a binary release can be configure via external string parameters
         // and NetworkParameters.fromID()
-        return MainNetParams.get();
+        return NamecoinMainNetParams.get();
     }
 
     @Bean


### PR DESCRIPTION
The libdohj dependency is retrieved via JitPack.  In the future, it might be useful to use a different Maven repo, but I don't think that's worth blocking the merge over.