### PR TITLE
Replace sendRawTransaction() with boolean param for Bitcoin Core 0.19+

### DIFF
--- a/bitcoinj-rpcclient/src/integ/groovy/com/msgilligan/bitcoinj/BaseRegTestSpec.groovy
+++ b/bitcoinj-rpcclient/src/integ/groovy/com/msgilligan/bitcoinj/BaseRegTestSpec.groovy
@@ -22,7 +22,10 @@ abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, 
     // Initializer to set up trait properties, Since Spock doesn't allow constructors
     {
         client = new BitcoinExtendedClient(RpcURI.defaultRegTestURI, rpcTestUser, rpcTestPassword)
-        fundingSource = new RegTestFundingSource(client)
+        RegTestFundingSource regTestFundingSource = new RegTestFundingSource(client)
+        regTestFundingSource.checkForLegacyBitcoinCore()    // Remove once we're Bitcoin Core 0.19+ only
+        fundingSource = regTestFundingSource
+
     }
 
     void setupSpec() {

--- a/bitcoinj-rpcclient/src/integ/groovy/com/msgilligan/bitcoinj/rpc/FundingAndBlockChainEnvIntSpec.groovy
+++ b/bitcoinj-rpcclient/src/integ/groovy/com/msgilligan/bitcoinj/rpc/FundingAndBlockChainEnvIntSpec.groovy
@@ -13,6 +13,7 @@ class FundingAndBlockChainEnvIntSpec extends Specification {
         given: "a client, a source of funds, and a blockchain environment"
         def client = new BitcoinExtendedClient(RpcURI.defaultRegTestURI, "bitcoinrpc", "pass")
         def funder = new RegTestFundingSource(client)
+        funder.checkForLegacyBitcoinCore()  // Remove once we're Bitcoin Core 0.19+ only
         RegTestEnvironment chainEnv = new RegTestEnvironment(client)
         // Mine some blocks and setup a source of funds for testing
         def myAddress = funder.createFundedAddress(1.btc)

--- a/cj-btc-jsonrpc/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinClient.java
@@ -538,18 +538,87 @@ public class BitcoinClient extends RpcClient implements NetworkParametersPropert
         return send("getrawtransaction", RawTransactionInfo.class, txid, 1);
     }
 
+    /**
+     * Submit a raw transaction to local node and network
+     *
+     * @since Bitcoin Core 0.19
+     * @param tx The raw transaction
+     * @param maxFeeRate  Reject transactions whose fee rate is higher than this value, expressed in BTC/kB.
+     *                    Set to 0 to accept any fee rate.
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     */
+    public Sha256Hash sendRawTransaction(Transaction tx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
+        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate);
+    }
+
+    /**
+     * Submit a raw transaction to local node and network
+     *
+     * @since Bitcoin Core 0.19
+     * @param hexTx The raw transaction as a hex-encoded string
+     * @param maxFeeRate  Reject transactions whose fee rate is higher than this value, expressed in BTC/kB.
+     *                    Set to 0 to accept any fee rate.
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     */
+    public Sha256Hash sendRawTransaction(String hexTx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
+        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate);
+    }
+
+    /**
+     * Submit a raw transaction to local node and network using server's default `maxFeeRate`
+     *
+     * @param tx The raw transaction
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     */
     public Sha256Hash sendRawTransaction(Transaction tx) throws JsonRpcStatusException, IOException {
-        return sendRawTransaction(tx, null);
+        return sendRawTransaction(tx, (Coin) null);
     }
 
+    /**
+     * Submit a raw transaction to local node and network using server's default `maxFeeRate`
+     *
+     * @since Bitcoin Core 0.19
+     * @param hexTx The raw transaction as a hex-encoded string
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     */
     public Sha256Hash sendRawTransaction(String hexTx) throws JsonRpcStatusException, IOException {
-        return sendRawTransaction(hexTx, null);
+        return sendRawTransaction(hexTx, (Coin) null);
     }
 
+    /**
+     * Submit a raw transaction to local node and network
+     *
+     * @param tx The raw transaction
+     * @param allowHighFees deprecated boolean parameter
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     * @deprecated In Bitcoin Core 0.19 and later, use {@link BitcoinClient#sendRawTransaction(Transaction, Coin)}
+     */
+    @Deprecated
     public Sha256Hash sendRawTransaction(Transaction tx, Boolean allowHighFees) throws JsonRpcStatusException, IOException {
         return send("sendrawtransaction", Sha256Hash.class, tx, allowHighFees);
     }
 
+    /**
+     * Submit a raw transaction to local node and network
+     *
+     * @param hexTx The raw transaction as a hex-encoded string
+     * @param allowHighFees deprecated boolean parameter
+     * @return SHA256 Transaction ID
+     * @throws JsonRpcStatusException JSON RPC status exception
+     * @throws IOException network error
+     * @deprecated In Bitcoin Core 0.19 and later, use {@link BitcoinClient#sendRawTransaction(Transaction, Coin)}
+     */
+    @Deprecated
     public Sha256Hash sendRawTransaction(String hexTx, Boolean allowHighFees) throws JsonRpcStatusException, IOException {
         return send("sendrawtransaction", Sha256Hash.class, hexTx, allowHighFees);
     }
@@ -876,7 +945,6 @@ public class BitcoinClient extends RpcClient implements NetworkParametersPropert
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, ChainTip.class);
         return send("getchaintips",resultType);
     }
-
 
     /**
      * Attempt to add or remove a node from the addnode list, or to try a connection to a node once.

--- a/cj-btc-jsonrpc/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/com/msgilligan/bitcoinj/rpc/BitcoinExtendedClient.java
@@ -18,14 +18,14 @@ import org.bitcoinj.params.RegTestParams;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
- * = Extended Bitcoin JSON-RPC Client with added convenience methods
+ * Extended Bitcoin JSON-RPC Client with added convenience methods.
  *
  * This class adds extra methods that aren't 1:1 mappings to standard
  * Bitcoin API RPC methods, but are useful for many common use cases -- specifically
@@ -61,7 +61,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
     public BitcoinExtendedClient(NetworkParameters netParams, URI server, String rpcuser, String rpcpassword) {
         super(netParams, server, rpcuser, rpcpassword);
         if (netParams.getId().equals(RegTestParams.ID_REGTEST)) {
-// TODO: If we want to do store mined coins on the client side, we might try this in the future
+// TODO: If we want to store mined coins on the client side, we might try this in the future
 //
 //            regTestMiningKey = new ECKey();
 //            regTestMiningAddress = Address.fromKey(RegTestParams.get(), regTestMiningKey, defaultScriptType);
@@ -79,22 +79,6 @@ public class BitcoinExtendedClient extends BitcoinClient {
         this(RegTestParams.get(), config.getURI(), config.getUsername(), config.getPassword());
     }
 
-    /**
-     *
-     * @deprecated Use BitcoinExtendedClient#generateBlocks or BitcoinClient#generateToAddress instead
-     */
-    @Deprecated
-    @Override
-    public List<Sha256Hash> generate(int numBlocks) throws JsonRpcStatusException, IOException {
-        return this.generateBlocks(numBlocks);
-    }
-
-    @Deprecated
-    @Override
-    public List<Sha256Hash> generate() throws IOException, JsonRpcStatusException {
-        return generateBlocks(1);
-    }
-
     public Address getRegTestMiningAddress() {
         return regTestMiningAddress;
     }
@@ -104,7 +88,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      *
      * Use this to generate blocks and receive the block reward in {@code this.regTestMiningAddress}
      * which can the be used to fund transactions in RegTest mode.
-     * 
+     *
      * @param numBlocks Number of blocks to mine
      * @return list of block hashes
      * @throws JsonRpcStatusException something broke
@@ -116,6 +100,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
 
     /**
      * Returns information about a block at index provided.
+     *
      * Use two RPCs: `getblockhash` and then `getblock`.
      * Note: somewhat-overrides (primitive vs boxed) deprecated method that will be removed.
      * The deprecated method in `BitcoinClient` takes an `Integer`, this method
@@ -134,7 +119,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
     /**
      * Creates a raw transaction, spending from a single address, whereby no new change address is created, and
      * remaining amounts are returned to {@code fromAddress}.
-     *
+     * <p>
      * Note: the transaction inputs are not signed, and the transaction is not stored in the wallet or transmitted to
      * the network.
      *
@@ -143,41 +128,46 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return The hex-encoded raw transaction
      */
     public String createRawTransaction(Address fromAddress, Map<Address, Coin> outputs) throws JsonRpcStatusException, IOException {
+        // Copy the Map (which may be immutable) and add prepare change output if needed.
+        Map<Address, Coin> outputsWithChange = new HashMap<>(outputs);
         // Get unspent outputs via RPC
         List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, Collections.singletonList(fromAddress));
 
-        // Gather inputs
-        List<Outpoint> inputs = new ArrayList<>();
-        for (UnspentOutput input : unspentOutputs) {
-            inputs.add(new Outpoint(input.getTxid(), input.getVout()));
-        }
+        // Gather inputs as OutPoints
+        List<Outpoint> inputs = unspentOutputs.stream()
+                .map(this::unspentToOutpoint)
+                .collect(Collectors.toList());
 
         // Calculate change
-        long amountIn = 0;
-        long amountOut = 0;
-        for (UnspentOutput it : unspentOutputs) {
-            amountIn += it.getAmount().value;
-        }
-        for (Coin it : outputs.values()) {
-            amountOut += it.value;
-        }
-        Coin amountChange = Coin.valueOf(amountIn - amountOut - stdTxFee.value);
-        if (amountIn < (amountOut + stdTxFee.value)) {
+        final long amountIn = unspentOutputs
+                .stream()
+                .map(UnspentOutput::getAmount)
+                .mapToLong(Coin::getValue)
+                .sum();
+        final long amountOut = outputs.values()
+                .stream()
+                .mapToLong(Coin::getValue)
+                .sum();
+
+        // Change is the difference less the standard transaction fee
+        final long amountChange = amountIn - amountOut - stdTxFeeSatoshis;
+        if (amountChange < 0) {
+            // TODO: Throw Exception
             System.out.println("Insufficient funds"); // + ": ${amountIn} < ${amountOut + stdTxFee}"
         }
-        // Copy the Map (which may be immutable) and add change output if needed.
-        Map<Address,Coin> outputsWithChange = new HashMap<>(outputs);
-        if (amountChange.value > 0) {
-            outputsWithChange.put(fromAddress, amountChange);
+        if (amountChange > 0) {
+            // Add a change output that returns change to sending address
+            outputsWithChange.put(fromAddress, Coin.valueOf(amountChange));
         }
 
+        // Call the server to create the transaction
         return createRawTransaction(inputs, outputsWithChange);
     }
 
     /**
      * Creates a raw transaction, sending {@code amount} from a single address to a destination, whereby no new change
      * address is created, and remaining amounts are returned to {@code fromAddress}.
-     *
+     * <p>
      * Note: the transaction inputs are not signed, and the transaction is not stored in the wallet or transmitted to
      * the network.
      *
@@ -187,14 +177,11 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return The hex-encoded raw transaction
      */
     public String createRawTransaction(Address fromAddress, Address toAddress, Coin amount) throws JsonRpcStatusException, IOException {
-        Map<Address, Coin> outputs = Collections.singletonMap(toAddress, amount);
-        return createRawTransaction(fromAddress, outputs);
+        return createRawTransaction(fromAddress, Collections.singletonMap(toAddress, amount));
     }
 
-
-
     /**
-     * Returns the Bitcoin balance of an address.
+     * Returns the Bitcoin balance of an address (in the server-side wallet.)
      *
      * @param address The address
      * @return The balance
@@ -208,7 +195,8 @@ public class BitcoinExtendedClient extends BitcoinClient {
     }
 
     /**
-     * Returns the Bitcoin balance of an address where spendable outputs have at least {@code minConf} confirmations.
+     * Returns the Bitcoin balance of an address (in the server-side wallet) where spendable outputs have at least
+     * {@code minConf} confirmations.
      *
      * @param address The address
      * @param minConf Minimum amount of confirmations
@@ -219,8 +207,8 @@ public class BitcoinExtendedClient extends BitcoinClient {
     }
 
     /**
-     * Returns the Bitcoin balance of an address where spendable outputs have at least {@code minConf} and not more
-     * than {@code maxConf} confirmations.
+     * Returns the Bitcoin balance of an address (in the server-side wallet) where spendable outputs have at least
+     * {@code minConf} and not more than {@code maxConf} confirmations.
      *
      * @param address The address (must be in wallet)
      * @param minConf Minimum amount of confirmations
@@ -273,45 +261,64 @@ public class BitcoinExtendedClient extends BitcoinClient {
         return txid;
     }
 
+    /**
+     * Create a signed transaction locally (i.e. with a client-side key.) Finds UTXOs this
+     * key can spend (assuming they are Script.ScriptType.P2PKH UTXOs)
+     *
+     * @param fromKey Signing key
+     * @param outputs Outputs to sign
+     * @return A bitcoinj Transaction objects that is properly signed
+     * @throws JsonRpcStatusException A JSON-RPC error was returned
+     * @throws IOException            An I/O error occured
+     */
     public Transaction createSignedTransaction(ECKey fromKey, List<TransactionOutput> outputs) throws JsonRpcStatusException, IOException {
         Address fromAddress = Address.fromKey(getNetParams(), fromKey, Script.ScriptType.P2PKH);
-        Transaction tx = new Transaction(getNetParams());
 
+        Transaction tx = new Transaction(getNetParams());   // Create a new transaction
+        outputs.forEach(tx::addOutput);                     // Add all requested outputs to it
+
+        // Fetch all UTXOs for the sending Address
         List<TransactionOutput> unspentOutputs = listUnspentJ(fromAddress);
 
-        // Add outputs to the transaction
-        for (TransactionOutput it : outputs) {
-            tx.addOutput(it);
-        }
-
         // Calculate change (units are satoshis)
-//        long amountIn     = (long) unspentOutputs.sum { TransactionOutput it -> it.value.longValue() }
-        long amountIn = 0;
-        for (TransactionOutput it : unspentOutputs) {
-            amountIn += it.getValue().value;
-        }
-//        long amountOut    = (long) outputs.sum { TransactionOutput it -> it.value.longValue() }
-        long amountOut = 0;
-        for (TransactionOutput it : outputs) {
-            amountOut += it.getValue().value;
-        }
-        long amountChange = amountIn - amountOut - stdTxFeeSatoshis;
+        // First sum all available UTXOs
+        final long amountIn = unspentOutputs.stream()
+                .map(TransactionOutput::getValue)
+                .mapToLong(Coin::getValue)
+                .sum();
+        // Then sum the requested outputs for this transaction
+        final long amountOut = outputs.stream()
+                .map(TransactionOutput::getValue)
+                .mapToLong(Coin::getValue)
+                .sum();
+        // Change is the difference less the standard transaction fee
+        final long amountChange = amountIn - amountOut - stdTxFeeSatoshis;
         if (amountChange < 0) {
             // TODO: Throw Exception
             System.out.println("Insufficient funds"); // + ": ${amountIn} < ${amountOut + stdTxFeeSatoshis}"
         }
         if (amountChange > 0) {
-            // Add a change output
+            // Add a change output that returns change to sending address
             tx.addOutput(Coin.valueOf(amountChange), fromAddress);
         }
 
-        // Add all UTXOs for fromAddress as inputs
-        for (TransactionOutput it : unspentOutputs) {
-            tx.addSignedInput(it, fromKey);
-        }
+        // Add *all* UTXOs for fromAddress as inputs (this perhaps unnecessarily consolidates coins, with
+        // a higher tx fee and some loss of privacy) and sign them
+        unspentOutputs.forEach(unspent -> tx.addSignedInput(unspent, fromKey));
         return tx;
     }
 
+    /**
+     * Create a signed transaction locally (i.e. with a client-side key.) Finds UTXOs this
+     * key can spend (assuming they are Script.ScriptType.P2PKH UTXOs)
+     *
+     * @param fromKey   Signing key
+     * @param toAddress Destination address
+     * @param amount    Amount to send
+     * @return A bitcoinj Transaction objects that is properly signed
+     * @throws JsonRpcStatusException A JSON-RPC error was returned
+     * @throws IOException            An I/O error occured
+     */
     public Transaction createSignedTransaction(ECKey fromKey, Address toAddress, Coin amount) throws JsonRpcStatusException, IOException {
         List<TransactionOutput> outputs = Collections.singletonList(
                 new TransactionOutput(getNetParams(), null, amount, toAddress));
@@ -319,29 +326,68 @@ public class BitcoinExtendedClient extends BitcoinClient {
     }
 
     /**
-     * Build a list of bitcoinj <code>TransactionOutput</code>s using <code>listUnspent</code>
-     * and <code>getRawTransaction</code> RPCs
+     * Build a list of bitcoinj {@link TransactionOutput}s using {@link BitcoinClient#listUnspent}
+     * and {@link BitcoinClient#getRawTransaction} RPCs.
      *
      * @param fromAddress Address to get UTXOs for
      * @return All unspent TransactionOutputs for fromAddress
      */
     public List<TransactionOutput> listUnspentJ(Address fromAddress) throws JsonRpcStatusException, IOException {
         List<Address> addresses = Collections.singletonList(fromAddress);
-        List<UnspentOutput> unspentOutputsRPC = listUnspent(0, defaultMaxConf, addresses); // RPC UnspentOutput objects
-        List<TransactionOutput> unspentOutputsJ = new ArrayList<TransactionOutput>();
-        for (UnspentOutput it : unspentOutputsRPC) {
-            unspentOutputsJ.add(getRawTransaction(it.getTxid()).getOutput(it.getVout()));
-        }
-        return unspentOutputsJ;
+        List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, addresses); // RPC UnspentOutput objects
+        return unspentOutputs.stream()
+                .map(this::unspentToTransactionOutput)
+                .collect(Collectors.toList());
     }
 
+    /**
+     * Build a list of bitcoinj {@link TransactionOutPoint}s using {@link BitcoinClient#listUnspent}.
+     *
+     * @param fromAddress Address to get UTXOs for
+     * @return All unspent TransactionOutPoints for fromAddress
+     */
     public List<TransactionOutPoint> listUnspentOutPoints(Address fromAddress) throws JsonRpcStatusException, IOException {
         List<Address> addresses = Collections.singletonList(fromAddress);
         List<UnspentOutput> unspentOutputsRPC = listUnspent(0, defaultMaxConf, addresses); // RPC UnspentOutput objects
-        List<TransactionOutPoint> unspentOutPoints = new ArrayList<TransactionOutPoint>();
-        for (UnspentOutput it : unspentOutputsRPC) {
-            unspentOutPoints.add(new TransactionOutPoint(getNetParams(), it.getVout(), it.getTxid()));
+        return unspentOutputsRPC.stream()
+                .map(this::unspentToTransactionOutpoint)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Convert an {@link UnspentOutput} JSONRPC-POJO to a *bitcoinj* {@link TransactionOutput} (that's out-PUT).
+     * Calls {@link BitcoinClient#getRawTransaction(Sha256Hash)}
+     * for every item. Throws {@link RuntimeException} if any of those RPC calls fails.
+     *
+     * @param unspentOutput The input POJO
+     * @return The *bitcoinj* object  (that's out-PUT)
+     */
+    private TransactionOutput unspentToTransactionOutput(UnspentOutput unspentOutput) {
+        try {
+            return getRawTransaction(unspentOutput.getTxid())
+                    .getOutput(unspentOutput.getVout());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        return unspentOutPoints;
+    }
+
+    /**
+     * Convert an {@link UnspentOutput} JSONRPC-POJO to a *bitcoinj* {@link TransactionOutPoint} (that's out-POINT).
+     *
+     * @param unspentOutput The input POJO
+     * @return The *bitcoinj* object  (that's out-POINT)
+     */
+    private TransactionOutPoint unspentToTransactionOutpoint(UnspentOutput unspentOutput) {
+        return new TransactionOutPoint(getNetParams(), unspentOutput.getVout(), unspentOutput.getTxid());
+    }
+
+    /**
+     * Convert an {@link UnspentOutput} JSONRPC-POJO to a JSONRPC-POJO {@link Outpoint} .
+     *
+     * @param unspentOutput The input UnspentOutput POJO
+     * @return the Outpoint POJO
+     */
+    private Outpoint unspentToOutpoint(UnspentOutput unspentOutput) {
+        return new Outpoint(unspentOutput.getTxid(), unspentOutput.getVout());
     }
 }


### PR DESCRIPTION
* Deprecate `sendRawTransaction(Transaction tx, Boolean allowHighFees)`
* Replace with `sendRawTransaction(Transaction tx, Coin maxFeeRate)`
  (available in Bitcoin Core 0.19 and later)
* Create temporary `checkForLegacyBitcoinCore()` method in `RegTestFundingSource`
* Remove deprecated `generate()` methods in `BitcoinExtendedClient`
* Related and semi-related code cleanup in `BitcoinClient`, `BitcoinExtendedClient`,
  and `BitcoinExtnededClientSpec`