### PR TITLE
bitcoinj Coin math, use new methods from bitcoinj 0.16

### DIFF
--- a/cj-bitcoinj-dsl-gvy/src/main/groovy/org/consensusj/bitcoin/dsl/groovy/categories/CoinCategory.groovy
+++ b/cj-bitcoinj-dsl-gvy/src/main/groovy/org/consensusj/bitcoin/dsl/groovy/categories/CoinCategory.groovy
@@ -3,30 +3,21 @@ package org.consensusj.bitcoin.dsl.groovy.categories
 import groovy.transform.CompileStatic
 import org.bitcoinj.core.Coin
 
-import java.math.MathContext
-import java.math.RoundingMode
-
 /**
  * Add convenience methods to Coin
  */
 @CompileStatic
 @Category(Coin)
 class CoinCategory {
-    // Note: this duplicates code in json.conversion.BitcoinMath, but we don't want to depend on any other modules
-    // Maybe basic conversion code needs to go to a standalone package or become part of `bitcoinj-core`.
-    //
-    private static final int DEFAULT_SCALE = Coin.SMALLEST_UNIT_EXPONENT;
-    private static final BigDecimal bdSatoshiPerCoin = new BigDecimal(Coin.COIN.value);
-
     /**
      * Convert to BTC in BigDecimal format
      *
      * @return a BigDecimal object
+     * @deprecated Use {@link Coin#toBtc()}
      */
+    @Deprecated
     public BigDecimal getDecimalBtc() {
-        MathContext context = new MathContext(Coin.SMALLEST_UNIT_EXPONENT, RoundingMode.UNNECESSARY);
-        BigDecimal satoshi = new BigDecimal(value, context)
-        return satoshi.divide(bdSatoshiPerCoin, DEFAULT_SCALE, RoundingMode.UNNECESSARY)
+        return this.toBtc();
     }
 
     // TODO: Needs more tests!

--- a/cj-bitcoinj-dsl-gvy/src/main/groovy/org/consensusj/bitcoin/dsl/groovy/categories/NumberCategory.groovy
+++ b/cj-bitcoinj-dsl-gvy/src/main/groovy/org/consensusj/bitcoin/dsl/groovy/categories/NumberCategory.groovy
@@ -33,16 +33,16 @@ class NumberCategory {
     }
 
     private static Coin btcAsCoin(Number self) {
-        return Coin.valueOf(btcToSatoshi(self))
+        return Coin.ofSat(btcToSatoshi(self))
     }
 
     private static Coin satoshiAsCoin(Number self) {
-        return Coin.valueOf(asSatoshi(self))
+        return Coin.ofSat(asSatoshi(self))
     }
 
     private static long btcToSatoshi(Number self) {
         switch(self) {
-            case BigDecimal:    return ((BigDecimal) self).multiply(satoshiPerBTCDecimal).longValueExact()
+            case BigDecimal:    return Coin.btcToSatoshi((BigDecimal) self)
             case BigInteger:    return ((BigInteger) self).multiply(satoshiPerBTCBigInt).longValue()
             default:            return self.longValue() *  Coin.COIN.value
         }

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/BitcoinMath.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/BitcoinMath.java
@@ -8,7 +8,9 @@ import java.math.RoundingMode;
 
 /**
  * Utilities for Bitcoin Math
+ * @deprecated All methods are obsoleted by methods in bitcoinj 0.16
  */
+@Deprecated
 public class BitcoinMath {
     public static final MathContext DEFAULT_CONTEXT = new MathContext(0, RoundingMode.UNNECESSARY);
     public static final int DEFAULT_SCALE = Coin.SMALLEST_UNIT_EXPONENT;
@@ -19,10 +21,11 @@ public class BitcoinMath {
      *
      * @param btc Bitcoin amount in BTC units
      * @return number of satoshi (long)
+     * @deprecated Use {@link Coin#btcToSatoshi(BigDecimal)}
      */
+    @Deprecated
     public static long btcToSatoshi(final BigDecimal btc) {
-        BigDecimal satoshisDecimal = btc.multiply(satoshiPerCoinDecimal);
-        return satoshisDecimal.longValueExact();
+        return Coin.btcToSatoshi(btc);
     }
 
     /**
@@ -30,10 +33,11 @@ public class BitcoinMath {
      *
      * @param satoshi number of satoshi (long)
      * @return Bitcoin amount in BTC units
+     * @deprecated Use {@link Coin#satoshiToBtc(long)}
      */
+    @Deprecated
     public static BigDecimal satoshiToBtc(final long satoshi) {
-        BigDecimal bdSatoshi = new BigDecimal(satoshi, BitcoinMath.DEFAULT_CONTEXT);
-        return bdSatoshi.divide(satoshiPerCoinDecimal, DEFAULT_SCALE, RoundingMode.UNNECESSARY);
+        return Coin.satoshiToBtc(satoshi);
     }
 
     /**
@@ -41,9 +45,11 @@ public class BitcoinMath {
      *
      * @param btc Bitcoin amount in BTC units
      * @return bitcoinj `Coin` type (uses satoshi unit internally)
+     * @deprecated Use {@link Coin#ofBtc(BigDecimal)}
      */
+    @Deprecated
     public static Coin btcToCoin(final BigDecimal btc) {
-        return Coin.valueOf(btcToSatoshi(btc));
+        return Coin.ofBtc(btc);
     }
 
     /**
@@ -51,8 +57,10 @@ public class BitcoinMath {
      *
      * @param coin Coin value to convert to BTC
      * @return  Bitcoin amount in BTC units
+     * @deprecated Use {@link Coin#toBtc()}
      */
+    @Deprecated
     public static BigDecimal coinToBTC(final Coin coin) {
-         return satoshiToBtc(coin.value);
+         return coin.toBtc();
     }
 }

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/CoinDeserializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/CoinDeserializer.java
@@ -21,11 +21,12 @@ public class CoinDeserializer extends JsonDeserializer<Coin> {
 
             case VALUE_NUMBER_FLOAT:
                 BigDecimal bd = p.getDecimalValue();
-                return BitcoinMath.btcToCoin(bd);
+                return Coin.ofBtc(bd);
 
             case VALUE_NUMBER_INT:
+                // TODO: Is this really what we want here? To treat JSON floats as BTC values and JSON integers as Satoshis?
                 long val = p.getNumberValue().longValue(); // should be optimal, whatever it is
-                return Coin.valueOf(val);
+                return Coin.ofSat(val);
 
             // TODO: Allow reading a numeric string. There seem to be cases where a BTC decimal balance
             // is encoded wrapped with quotes.

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/CoinSerializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/CoinSerializer.java
@@ -13,7 +13,7 @@ import java.io.IOException;
  */
 public class CoinSerializer  extends JsonSerializer<Coin> {
     @Override
-    public void serialize(Coin value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
-        gen.writeNumber(BitcoinMath.coinToBTC(value));
+    public void serialize(Coin coin, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        gen.writeNumber(coin.toBtc());
     }
 }


### PR DESCRIPTION
**bitcoinj** 0.16 added:

* `Coin.ofBtc(BigDecimal)`
* `Coin.ofSat(long)`
* `Coin.btcToSatoshi(BigDecimal)`
* `Coin.satoshiToBtc(long)`

This can replace our custom logic to do similar things and makes `BitcoinMath` completely obsolete.