### PR TITLE
Bitcoin(Extended)Client: listUnspent param changes, use JDK 9 to simplify collections

### DIFF
--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
@@ -740,7 +740,7 @@ public class BitcoinClient extends JsonRpcClientHttpUrlConnection implements Cha
      * @throws IOException network error
      */
     public List<UnspentOutput> listUnspent() throws JsonRpcStatusException, IOException {
-        return listUnspent(null, null, null);
+        return listUnspent(null, null, null, null);
     }
 
     /**
@@ -755,10 +755,15 @@ public class BitcoinClient extends JsonRpcClientHttpUrlConnection implements Cha
      */
     public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf)
             throws JsonRpcStatusException, IOException {
-        return listUnspent(minConf, maxConf, null);
+        return listUnspent(minConf, maxConf, null, null);
     }
 
-    public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf, Iterable<Address> filter)
+    public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf, Address address)
+            throws JsonRpcStatusException, IOException {
+        return listUnspent(minConf, maxConf, List.of(address), true);
+    }
+
+    public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf, List<Address> filter)
             throws JsonRpcStatusException, IOException {
         return listUnspent(minConf, maxConf, filter, true);
     }
@@ -770,11 +775,12 @@ public class BitcoinClient extends JsonRpcClientHttpUrlConnection implements Cha
      * @param minConf The minimum confirmations to filter
      * @param maxConf The maximum confirmations to filter
      * @param filter  Include only transaction outputs to the specified addresses
+     * @param includeUnsafe optional
      * @return The unspent transaction outputs
      * @throws JsonRpcStatusException JSON RPC status exception
      * @throws IOException network error
      */
-    public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf, Iterable<Address> filter, boolean includeUnsafe)
+    public List<UnspentOutput> listUnspent(Integer minConf, Integer maxConf, List<Address> filter, Boolean includeUnsafe)
             throws JsonRpcStatusException, IOException {
         JavaType resultType = mapper.getTypeFactory().constructCollectionType(List.class, UnspentOutput.class);
         return send("listunspent", resultType, minConf, maxConf, filter, includeUnsafe);

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -179,7 +179,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
         // Copy the Map (which may be immutable) and add prepare change output if needed.
         Map<Address, Coin> outputsWithChange = new HashMap<>(outputs);
         // Get unspent outputs via RPC
-        List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, Collections.singletonList(fromAddress));
+        List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, fromAddress);
 
         // Gather inputs as OutPoints
         List<Outpoint> inputs = unspentOutputs.stream()
@@ -264,7 +264,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return The balance
      */
     public Coin getBitcoinBalance(Address address, Integer minConf, Integer maxConf) throws JsonRpcStatusException, IOException {
-        return listUnspent(minConf, maxConf, Collections.singletonList(address))
+        return listUnspent(minConf, maxConf, address)
                 .stream()
                 .map(UnspentOutput::getAmount)
                 .reduce(Coin.ZERO, Coin::add);
@@ -362,7 +362,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @throws IOException            An I/O error occured
      */
     public Transaction createSignedTransaction(ECKey fromKey, Address toAddress, Coin amount) throws JsonRpcStatusException, IOException {
-        List<TransactionOutput> outputs = Collections.singletonList(
+        List<TransactionOutput> outputs = List.of(
                 new TransactionOutput(getNetParams(), null, amount, toAddress));
         return createSignedTransaction(fromKey, outputs);
     }
@@ -375,8 +375,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return All unspent TransactionOutputs for fromAddress
      */
     public List<TransactionOutput> listUnspentJ(Address fromAddress) throws JsonRpcStatusException, IOException {
-        List<Address> addresses = Collections.singletonList(fromAddress);
-        List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, addresses); // RPC UnspentOutput objects
+        List<UnspentOutput> unspentOutputs = listUnspent(0, defaultMaxConf, fromAddress); // RPC UnspentOutput objects
         return unspentOutputs.stream()
                 .map(this::unspentToTransactionOutput)
                 .collect(Collectors.toList());
@@ -389,8 +388,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return All unspent TransactionOutPoints for fromAddress
      */
     public List<TransactionOutPoint> listUnspentOutPoints(Address fromAddress) throws JsonRpcStatusException, IOException {
-        List<Address> addresses = Collections.singletonList(fromAddress);
-        List<UnspentOutput> unspentOutputsRPC = listUnspent(0, defaultMaxConf, addresses); // RPC UnspentOutput objects
+        List<UnspentOutput> unspentOutputsRPC = listUnspent(0, defaultMaxConf, fromAddress); // RPC UnspentOutput objects
         return unspentOutputsRPC.stream()
                 .map(this::unspentToTransactionOutpoint)
                 .collect(Collectors.toList());


### PR DESCRIPTION
* listUnspent: Change Iterable<Address> to List<Address>
* listUnspent: Add convenience overload that takes a single address
* listUnspent: Boolean (rather than boolean) for includeUnsafe
* BitcoinExtendedClient: Use new listUnspent overload and List.of() to simplify
* RegTestFundingSource: Simplify calcChange, use Map.of(), other simplifications