### PR TITLE
Bitcoin JSON-RPC: Support Bitcoin Core v23.0 createwallet/unloadwallet

### DIFF
--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/LoadWalletResult.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/LoadWalletResult.java
@@ -1,0 +1,27 @@
+package org.consensusj.bitcoin.json.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response object for {@code createwallet} and {@code loadwallet}
+ */
+public class LoadWalletResult {
+      private final String name;
+      private final String warning;
+
+
+    @JsonCreator
+    public LoadWalletResult(@JsonProperty("name") String name, @JsonProperty("warning") String warning) {
+        this.name = name;
+        this.warning = warning;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getWarning() {
+        return warning;
+    }
+}

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnloadWalletResult.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnloadWalletResult.java
@@ -1,0 +1,20 @@
+package org.consensusj.bitcoin.json.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response object for {@code createwallet} and {@code loadwallet}
+ */
+public class UnloadWalletResult {
+    private final String warning;
+    
+    @JsonCreator
+    public UnloadWalletResult(@JsonProperty("warning") String warning) {
+        this.warning = warning;
+    }
+    
+    public String getWarning() {
+        return warning;
+    }
+}

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/TxTestBaseSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/TxTestBaseSpec.groovy
@@ -7,7 +7,7 @@ import spock.lang.Shared
 
 /**
  * Base test class for testing bitcoinj transactions via P2P and RPC on RegTest
- * TODO: There inheritence of BitcoinClientDelegate through both BaseRegTestSpec and
+ * TODO: The inheritance of BitcoinClientDelegate through both BaseRegTestSpec and
  * JTransactionTestSupport seems to cause delegated calls (e.g. getNetParams()) to
  * get a NPE when looking for the client property.
  */

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
@@ -1,0 +1,51 @@
+package org.consensusj.bitcoin.rpc.wallet
+
+import org.consensusj.bitcoin.jsonrpc.test.WalletTestUtil
+import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.Requires
+
+/**
+ * Test Spec for {@code createwallet}
+ */
+class CreateWalletSpec extends BaseRegTestSpec {
+
+    @Requires({ instance.clientInstance.getServerVersion() >= 210000})
+    def "create and unload new non-descriptor wallet"() {
+        given: "A random wallet name and a client instance for that wallet URL"
+        var walletName = WalletTestUtil.randomWalletName()
+        var walletClient = client.withWallet(walletName, rpcTestUser, rpcTestPassword)
+
+        when: "we create a wallet"
+        var createResult = walletClient.createWallet(walletName, null, null, null, null)
+
+        then: "creation was successful"
+        createResult.name == walletName
+        createResult.warning == ""
+
+        when: "we unload the wallet"
+        var unloadResult = walletClient.unloadWallet()
+
+        then: "it works"
+        unloadResult.warning == ""
+    }
+
+    @Requires({ instance.clientInstance.getServerVersion() >= 230000})
+    def "create and unload new descriptor wallet"() {
+        given: "A random wallet name and a client instance for that wallet URL"
+        var walletName = WalletTestUtil.randomWalletName()
+        var walletClient = client.withWallet(walletName, rpcTestUser, rpcTestPassword)
+
+        when: "we create a wallet"
+        var createResult = walletClient.createWallet(walletName, null, null, null, null, true, null, null)
+
+        then: "creation was successful"
+        createResult.name == walletName
+        createResult.warning == ""
+
+        when: "we unload the wallet"
+        var unloadResult = walletClient.unloadWallet()
+
+        then: "it works"
+        unloadResult.warning == ""
+    }
+}

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -2,6 +2,7 @@ package org.consensusj.bitcoin.jsonrpc;
 
 import com.fasterxml.jackson.databind.JavaType;
 import org.consensusj.bitcoin.json.pojo.AddressInfo;
+import org.consensusj.bitcoin.json.pojo.LoadWalletResult;
 import org.consensusj.bitcoin.json.pojo.Outpoint;
 import org.consensusj.bitcoin.json.pojo.SignedRawTransaction;
 import org.consensusj.bitcoin.json.pojo.UnspentOutput;
@@ -83,6 +84,17 @@ public class BitcoinExtendedClient extends BitcoinClient {
      */
     public BitcoinExtendedClient() {
         this(BitcoinConfFile.readDefaultConfig().getRPCConfig());
+    }
+
+    /**
+     * Incubating: clone the client with a new base URI for a named wallet.
+     * @param walletName wallet name
+     * @param rpcUser username must be provided because it is not accessible in the parent class
+     * @param rpcPassword password must be provided because it is not accessible in the parent class
+     * @return A new client with a baseURI configured for the specified wallet name.
+     */
+    public BitcoinExtendedClient withWallet(String walletName, String rpcUser, String rpcPassword) {
+        return new BitcoinExtendedClient(this.getNetParams(), this.getServerURI().resolve("/wallet/" + walletName), rpcUser, rpcPassword);
     }
 
     public synchronized Address getRegTestMiningAddress() {

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/WalletTestUtil.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/WalletTestUtil.java
@@ -1,0 +1,40 @@
+package org.consensusj.bitcoin.jsonrpc.test;
+
+import java.util.Random;
+
+/**
+ * Utilities for integration testing server-side wallets
+ */
+public class WalletTestUtil {
+
+    /**
+     * Generate a valid, random wallet name. This is useful in integration testing.
+     *
+     * @return A wallet name of the form: <i>testwallet</i>-<i>ten-randomChars</i>
+     */
+    public static String randomWalletName() {
+        return randomWalletName("testwallet", 10);
+    }
+
+    /**
+     * Generate a valid, random wallet name. This is useful in integration testing.
+     *
+     * @param prefix Prefix, e.g. {@code "testwallet"}
+     * @param numRandomChars The number of random characters to add to the prefix
+     * @return A wallet name of the form: <i>prefix</i>-<i>randomChars</i>
+     */
+    public static String randomWalletName(String prefix, int numRandomChars) {
+        return String.format("%s-%s", prefix, generateRandomName(numRandomChars));
+    }
+
+    static String generateRandomName(int targetStringLength) {
+        int leftLimit = 97;     // letter 'a'
+        int rightLimit = 122;   // letter 'z'
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}


### PR DESCRIPTION
* Improve createwallet support for Bitcoin Core v23 (descriptor wallets)
* Add unloadwallet methods
* Add (incubating) BitcoinExtendedClient.withWallet() to clone a client with new wallet URL
* Add LoadWalletResult and UnloadWalletResult types
* RegTestFundingSource: Fix to make sure default wallet created is NOT a descriptor wallet
* Add Spock test CreateWalletSpec to create (and unload) wallets