### PR TITLE
btc-jsonrpc(-integ-test): Use named wallet for main RegTest wallet

### DIFF
--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseRegTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseRegTestSpec.groovy
@@ -24,7 +24,7 @@ abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, 
     static BitcoinExtendedClient getClientInstance() {
         // We use a shared client for RegTest integration tests, because we want a single value for regTestMiningAddress
         if (INSTANCE == null) {
-            INSTANCE = new BitcoinExtendedClient(RpcURI.defaultRegTestURI, rpcTestUser, rpcTestPassword)
+            INSTANCE = new BitcoinExtendedClient(RpcURI.getDefaultRegTestWalletURI(), rpcTestUser, rpcTestPassword)
         }
         return INSTANCE;
     }
@@ -39,9 +39,8 @@ abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, 
     void setupSpec() {
         serverReady(RegTestParams.get())
 
+        // TODO: Do we really need to keep doing this now that most tests explicitly fund their addresses?
         // Make sure we have enough test coins
-        // Do we really need to keep doing this now that most tests
-        // explicitly fund their addresses?
         while (client.getBalance() < minBTCForTests) {
             // Mine blocks until we have some coins to spend
             client.generateBlocks(1)

--- a/cj-btc-jsonrpc-integ-test/src/integ/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
+++ b/cj-btc-jsonrpc-integ-test/src/integ/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
@@ -42,7 +42,7 @@ public class WalletAppKitRegTest {
 
     @BeforeEach
     void setupTest(@TempDir File tempDir) throws UnknownHostException {
-        client = new BitcoinExtendedClient(netParams, RpcURI.getDefaultRegTestURI(), rpcTestUser, rpcTestPassword);
+        client = new BitcoinExtendedClient(netParams, RpcURI.getDefaultRegTestWalletURI(), rpcTestUser, rpcTestPassword);
         kit = new WalletAppKit(netParams,
                 Script.ScriptType.P2WPKH,
                 KeyChainGroupStructure.DEFAULT,

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -46,6 +46,8 @@ public class BitcoinExtendedClient extends BitcoinClient {
     private static final String RegTestMiningAddressLabel = "RegTestMiningAddress";
     private /* lazy */ Address regTestMiningAddress;
 
+    public static final String REGTEST_WALLET_NAME = "consensusj-regtest-wallet";
+
     public final Coin stdTxFee = Coin.valueOf(10000);
     public final Coin stdRelayTxFee = Coin.valueOf(1000);
     public final Integer defaultMaxConf = 9999999;

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/RpcURI.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/RpcURI.java
@@ -34,4 +34,8 @@ public interface RpcURI {
     static URI getDefaultRegTestURI() {
         return DEFAULT_REGTEST_URI;
     }
+
+    static URI getDefaultRegTestWalletURI() {
+        return DEFAULT_REGTEST_URI.resolve("/wallet/" + BitcoinExtendedClient.REGTEST_WALLET_NAME);
+    }
 }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
@@ -37,24 +37,26 @@ public class RegTestFundingSource implements FundingSource {
             throw new RuntimeException(ioe);
         }
 
-        // Bitcoin Core 0.21+ will not create default wallet (named "") if it doesn't exist, so we have to do it ourselves
-        if (bitcoinCoreVersion >= 210000) {
+        // Create a named wallet for RegTest (previously we used the default wallet with an empty-string name)
+        if (bitcoinCoreVersion >= 200000) {
             try {
                 List<String> walletList = client.listWallets();
-                if (!walletList.contains("")) {
+                if (!walletList.contains(BitcoinExtendedClient.REGTEST_WALLET_NAME)) {
                     LoadWalletResult result = (bitcoinCoreVersion >= 230000)
                         // Create a (non-descriptor) wallet
-                        ? client.createWallet("", false, false, null, null, false, null, null)
-                        : client.createWallet("", false, false, null, null);
+                        ? client.createWallet(BitcoinExtendedClient.REGTEST_WALLET_NAME, false, false, null, null, false, null, null)
+                        : client.createWallet(BitcoinExtendedClient.REGTEST_WALLET_NAME, false, false, null, null);
                     if (result.getWarning().isEmpty()) {
-                        log.info("Created default wallet: \"{}\"", result.getName());
+                        log.info("Created REGTEST wallet: \"{}\"", result.getName());
                     } else {
-                        log.warn("Warning creating default wallet \"{}\": {}", result.getName(), result.getWarning());
+                        log.warn("Warning creating REGTEST wallet \"{}\": {}", result.getName(), result.getWarning());
                     }
                 }
             } catch (IOException ioe) {
                 throw new RuntimeException(ioe);
             }
+        } else {
+            throw new RuntimeException("Unsupported Bitcoin JSON-RPC server version");
         }
     }
 


### PR DESCRIPTION
* This works with Bitcoin Core v0.20 (Omni Core v0.11.0) and later
* This allows tests to create additional wallets and run tests in them without causing the existing tests and test infrastructure to fail.

NOTE: RegTests will now throw an exception if Bitcoin Core version is less than v0.20