### PR TITLE
Groovy RPC test support: deprecate traits simplify inheritence

### DIFF
--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BitcoinClientDelegate.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BitcoinClientDelegate.groovy
@@ -1,11 +1,13 @@
 package org.consensusj.bitcoin.jsonrpc.groovy
 
 import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient
+import org.consensusj.bitcoin.jsonrpc.test.BitcoinClientAccessor
 
 /**
  * Trait to Mix-in BitcoinClient methods via Delegation pattern
  */
-trait BitcoinClientDelegate {
+@Deprecated
+trait BitcoinClientDelegate implements BitcoinClientAccessor {
     @Delegate
     BitcoinExtendedClient client
 

--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/BTCTestSupport.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/BTCTestSupport.groovy
@@ -1,27 +1,27 @@
 package org.consensusj.bitcoin.jsonrpc.groovy.test
 
+import groovy.transform.CompileStatic
 import org.bitcoinj.core.NetworkParameters
-import org.consensusj.bitcoin.jsonrpc.groovy.BitcoinClientDelegate
+import org.consensusj.bitcoin.jsonrpc.test.BitcoinClientAccessor
 
+// TODO: Migrate to Java
 /**
  * Test support functions intended to be mixed-in to Spock test specs
  */
-trait BTCTestSupport implements BitcoinClientDelegate, FundingSourceDelegate {
+@CompileStatic
+interface BTCTestSupport extends BitcoinClientAccessor {
 
     /**
      * Wait for the server to become ready and validate the Bitcoin network it is running on
      * @param expectedNetworkParams The network the server is expected to be running on
      */
-    void serverReady(NetworkParameters expectedNetworkParams) {
-        Boolean ready = client.waitForServer(60)   // Wait up to 1 minute
+    default void serverReady(NetworkParameters expectedNetworkParams) {
+        Boolean ready = client().waitForServer(60);   // Wait up to 1 minute
         if (!ready) {
-            throw new RuntimeException("Timeout waiting for server")
+            throw new RuntimeException("Timeout waiting for server");
         }
-        NetworkParameters params = client.getNetParams()
-        assert params.equals(expectedNetworkParams)
-    }
-
-    void consolidateCoins() {
-        fundingSource.fundingSourceMaintenance();
+        // As soon as the server is ready we must initialize network parameters in the client (by querying them)
+        NetworkParameters params = client().getNetParams();
+        assert params.equals(expectedNetworkParams);
     }
 }

--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/FundingSourceDelegate.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/FundingSourceDelegate.groovy
@@ -1,11 +1,13 @@
 package org.consensusj.bitcoin.jsonrpc.groovy.test
 
 import org.consensusj.bitcoin.jsonrpc.test.FundingSource
+import org.consensusj.bitcoin.jsonrpc.test.FundingSourceAccessor
 
 /**
  * Provide a funding source for a test Spec
  */
-trait FundingSourceDelegate {
+@Deprecated
+trait FundingSourceDelegate implements FundingSourceAccessor {
     @Delegate
     FundingSource fundingSource
 

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
@@ -1,6 +1,7 @@
 package org.consensusj.bitcoin.integ.bitcoinj
 
 import com.google.common.util.concurrent.ListenableFuture
+import groovy.util.logging.Slf4j
 import org.consensusj.bitcoin.json.pojo.WalletTransactionInfo
 import org.bitcoinj.core.TransactionBroadcast
 import org.bitcoinj.core.TransactionConfidence
@@ -29,6 +30,7 @@ import spock.lang.Stepwise
  * in {@link WalletSendSpec#setupSpec}. Since these are integration tests (not pure unit tests) and
  * communicate with the stateful Bitcoin blockchain, the {@code Stepwise} approach is helpful.
  */
+@Slf4j
 @Stepwise
 class WalletSendSpec extends BaseRegTestSpec {
     /**

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseMainNetTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseMainNetTestSpec.groovy
@@ -1,9 +1,9 @@
 package org.consensusj.bitcoin.test
 
+import groovy.util.logging.Slf4j
 import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient
 import org.bitcoinj.params.MainNetParams
 import org.consensusj.bitcoin.jsonrpc.groovy.test.BTCTestSupport
-import org.consensusj.jsonrpc.groovy.Loggable
 import org.consensusj.bitcoin.jsonrpc.RpcURI
 import org.consensusj.bitcoin.jsonrpc.test.TestServers
 import spock.lang.Specification
@@ -11,15 +11,25 @@ import spock.lang.Specification
 /**
  * Abstract Base class for Spock tests of Bitcoin Core on MainNet
  */
-abstract class BaseMainNetTestSpec extends Specification implements BTCTestSupport, Loggable {
+@Slf4j
+abstract class BaseMainNetTestSpec extends Specification implements BTCTestSupport {
     static final private TestServers testServers = TestServers.instance
     static final protected String rpcTestUser = testServers.rpcTestUser
     static final protected String rpcTestPassword = testServers.rpcTestPassword;
+    private static BitcoinExtendedClient INSTANCE;
 
-    // Initializer to set up trait properties, Since Spock doesn't allow constructors
-    {
-        client = new BitcoinExtendedClient(RpcURI.defaultMainNetURI, rpcTestUser, rpcTestPassword)
-        fundingSource = null    // No funding source implementation for MainNet yet.
+    @Delegate
+    @Override
+    BitcoinExtendedClient client() {
+        return getClientInstance();
+    }
+
+    static BitcoinExtendedClient getClientInstance() {
+        // We use a shared client for integration tests, to avoid repeated configuration fetch from server
+        if (INSTANCE == null) {
+            INSTANCE = new BitcoinExtendedClient(RpcURI.defaultMainNetURI, rpcTestUser, rpcTestPassword)
+        }
+        return INSTANCE;
     }
 
     void setupSpec() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseRegTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/test/BaseRegTestSpec.groovy
@@ -1,27 +1,43 @@
 package org.consensusj.bitcoin.test
 
+import groovy.util.logging.Slf4j
 import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient
 import org.bitcoinj.params.RegTestParams
 import org.consensusj.bitcoin.jsonrpc.groovy.test.BTCTestSupport
+import org.consensusj.bitcoin.jsonrpc.test.FundingSource
+import org.consensusj.bitcoin.jsonrpc.test.FundingSourceAccessor
 import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource
-import org.consensusj.jsonrpc.groovy.Loggable
 import org.consensusj.bitcoin.jsonrpc.RpcURI
-import org.bitcoinj.core.Coin
 import spock.lang.Specification
 import org.consensusj.bitcoin.jsonrpc.test.TestServers
-
 
 /**
  * Abstract Base class for Spock tests of Bitcoin Core in RegTest mode
  */
-abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, Loggable {
-    static final Coin minBTCForTests = 50.btc
+@Slf4j
+abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, FundingSourceAccessor {
     static final private TestServers testServers = TestServers.instance
     static final protected String rpcTestUser = testServers.rpcTestUser
     static final protected String rpcTestPassword = testServers.rpcTestPassword;
     private static BitcoinExtendedClient INSTANCE;
+    private static RegTestFundingSource FUNDING_INSTANCE;
 
-    static BitcoinExtendedClient getClientInstance() {
+    @Delegate
+    @Override
+    BitcoinExtendedClient client() {
+        return getClientInstance()
+    }
+
+    @Delegate
+    @Override
+    FundingSource fundingSource() {
+        if (FUNDING_INSTANCE == null) {
+            FUNDING_INSTANCE = new RegTestFundingSource(client())
+        }
+        return FUNDING_INSTANCE;
+    }
+
+    /*package */ static BitcoinExtendedClient getClientInstance() {
         // We use a shared client for RegTest integration tests, because we want a single value for regTestMiningAddress
         if (INSTANCE == null) {
             INSTANCE = new BitcoinExtendedClient(RpcURI.getDefaultRegTestWalletURI(), rpcTestUser, rpcTestPassword)
@@ -29,22 +45,8 @@ abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, 
         return INSTANCE;
     }
     
-    // Initializer to set up trait properties, Since Spock doesn't allow constructors
-    {
-        client = getClientInstance()
-        serverReady(RegTestParams.get())
-        fundingSource = new RegTestFundingSource(client)
-    }
-
     void setupSpec() {
         serverReady(RegTestParams.get())
-
-        // TODO: Do we really need to keep doing this now that most tests explicitly fund their addresses?
-        // Make sure we have enough test coins
-        while (client.getBalance() < minBTCForTests) {
-            // Mine blocks until we have some coins to spend
-            client.generateBlocks(1)
-        }
     }
 
     /**
@@ -55,4 +57,7 @@ abstract class BaseRegTestSpec extends Specification implements BTCTestSupport, 
         consolidateCoins()
     }
 
+    void consolidateCoins() {
+        fundingSource.fundingSourceMaintenance();
+    }
 }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/BitcoinClientAccessor.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/BitcoinClientAccessor.java
@@ -1,0 +1,23 @@
+package org.consensusj.bitcoin.jsonrpc.test;
+
+import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient;
+
+/**
+ * Interface for tests that use a BitcoinExtendedClient
+ */
+public interface BitcoinClientAccessor {
+
+    /**
+     * Preferred accessor
+     * @return The Bitcoin Client
+     */
+    BitcoinExtendedClient client();
+
+    /**
+     * JavaBeans style getter/accessor (for Groovy, etc)
+     * @return The Bitcoin Client
+     */
+    default BitcoinExtendedClient getClient() {
+        return client();
+    }
+}

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/FundingSourceAccessor.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/FundingSourceAccessor.java
@@ -1,0 +1,20 @@
+package org.consensusj.bitcoin.jsonrpc.test;
+
+/**
+ * Interface for tests that use a FundingSource
+ */
+public interface FundingSourceAccessor {
+    /**
+     * Preferred accessor
+     * @return The FundingSource
+     */
+    FundingSource fundingSource();
+
+    /**
+     * JavaBeans style getter/accessor (for Groovy, etc)
+     * @return The FundingSource
+     */
+    default FundingSource getFundingSource() {
+        return fundingSource();
+    }
+}

--- a/consensusj-jsonrpc-gvy/src/main/groovy/org/consensusj/jsonrpc/groovy/Loggable.groovy
+++ b/consensusj-jsonrpc-gvy/src/main/groovy/org/consensusj/jsonrpc/groovy/Loggable.groovy
@@ -4,8 +4,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
- * Adds an slf4j logger to a class. This is useful because we can't use the {@code @Slf4j} annotation on traits.
+ * Adds an slf4j logger to a class. This was useful because we couldn't use the {@code @Slf4j} annotation on traits.
+ * @deprecated We're deprecating most of our Groovy traits, so either use the {@code @Slf4j} annotation or define
+ * your own {@code trait}.
  */
+@Deprecated
 trait Loggable {
     private final Logger logger = LoggerFactory.getLogger( this.getClass() )
 


### PR DESCRIPTION
* Deprecate BitcoinClientDelegate.groovy
* Deprecate FundingSourceDelegate.groovy
* Create BitcoinClientAccessor.java
* Create FundingSourceAccessor.java
* Deprecate Loggable
* Convert BTCTestSupport to a @CompileStatic interface (maybe move to Java later)
* Use @Delegate annotation directly in BaseRegTestSpec, BaseMainNetTestSpec
* Move consolidateCoins to BaseRegTestSpec
* Use built-in @Slf4j annotation where needed