### PR TITLE
gradle.yml, regtest.yml: setup-java v3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v1
     - name: Set up JDK
-      uses: actions/setup-java@v2.2.0
+      uses: actions/setup-java@v3
       with:
         distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Download Omni Core (Bitcoin Core superset)
       run: ./test-download-omnicore-ubuntu.sh
     - name: Set up JDK
-      uses: actions/setup-java@v2.2.0
+      uses: actions/setup-java@v3
       with:
         distribution: ${{ matrix.distribution }}
         java-version: ${{ matrix.java }}


### PR DESCRIPTION
Upgrade setup-java to v3.

(I'm hoping this fixes an issue I'm seeing with the JDK 11 `regtest.yml` workflow of PR #88 hanging, but it's not a bad idea to upgrade anyway)