### PR TITLE
Micronaut 3.7.1, GraalVM 22.2

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        graalvm: [ '22.1.0' ]
+        graalvm: [ '22.2.0' ]
         java: [ 'java11', 'java17' ]
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}.${{ matrix.java }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,13 +46,14 @@ Released: Under-development
 === Dependency Updates
 
 * Jackson 2.13.4
+* Micronaut 3.7.1
 * Groovy 4.0.5
 * SLF4J 2.0.3
 
 === Build/Test Updates
 
 * Spock 2.3-groovy-4.0
-
+* GraalVM 22.2
 
 == v0.6.3
 

--- a/cj-btc-daemon/build.gradle
+++ b/cj-btc-daemon/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 
     compileOnly("org.graalvm.nativeimage:svm")
 
+    implementation('org.slf4j:slf4j-api:1.7.36') {
+        force = true
+    }
+
     runtimeOnly "ch.qos.logback:logback-classic:1.2.3"
 }
 

--- a/consensusj-jsonrpc-daemon/build.gradle
+++ b/consensusj-jsonrpc-daemon/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 
     compileOnly("org.graalvm.nativeimage:svm")
 
+    implementation('org.slf4j:slf4j-api:1.7.36') {
+        force = true
+    }
+
     runtimeOnly("ch.qos.logback:logback-classic")
 
     testImplementation project(':consensusj-jsonrpc-gvy')

--- a/doc/release-process.adoc
+++ b/doc/release-process.adoc
@@ -4,7 +4,7 @@
 
 . Use Java 17 for official builds
 .. `sdk use 17.0.4.1-tem`
-.. `sdk use 22.1.0.r17-grl` (for GraalVM build)
+.. `sdk use 22.2.r17-grl` (for GraalVM build)
 . Update `CHANGELOG.adoc`
 . Set versions
 .. `gradle.properties`

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,8 @@ groovyVersion = 4.0.5
 spockVersion = 2.3-groovy-4.0
 slf4jVersion = 2.0.3
 jacksonVersion = 2.13.4
-micronautVersion = 3.4.4
-micronautAppGradlePluginVersion = 3.4.0
+micronautVersion = 3.7.1
+micronautAppGradlePluginVersion = 3.6.2
 javaMoneyApiVersion = 1.1
 javaMoneyMonetaVersion = 1.4.2
 


### PR DESCRIPTION
Upgrade to Micronaut 3.7.1 and GraalVM 22.2 for `nativeCompile`

Also force Micronaut projects to use SLF4J 1.7.36 for compatibility.