### PR TITLE
BlockChainInfo: fix case errors in JsonProperty constructor annotations

### DIFF
--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockChainInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockChainInfo.java
@@ -26,8 +26,8 @@ public class BlockChainInfo {
                           @JsonProperty("headers")          int headers,
                           @JsonProperty("bestblockhash")        Sha256Hash bestBlockHash,
                           @JsonProperty("difficulty")           BigDecimal difficulty,
-                          @JsonProperty("verificationProgress") BigDecimal verificationProgress,
-                          @JsonProperty("chainWork")            byte[] chainWork) {
+                          @JsonProperty("verificationprogress") BigDecimal verificationProgress,
+                          @JsonProperty("chainwork")            byte[] chainWork) {
         this.chain = chain;
         this.blocks = blocks;
         this.headers = headers;

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetBlockChainInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetBlockChainInfoSpec.groovy
@@ -1,0 +1,24 @@
+package org.consensusj.bitcoin.rpc.blockchain
+
+import org.bitcoinj.core.Sha256Hash
+import org.consensusj.bitcoin.json.pojo.BlockChainInfo
+import org.consensusj.bitcoin.test.BaseRegTestSpec
+
+/**
+ * Functional test of `gettxoutsetinfo` via {@link BitcoinClient#getBlockChainInfo}
+ */
+class GetBlockChainInfoSpec extends BaseRegTestSpec {
+    def "response fields are present and pass minimal consistency checks "() {
+        when: "we call the RPC"
+        BlockChainInfo blockChainInfo = getBlockChainInfo()
+
+        then: "The result passes basic sanity checks"
+        blockChainInfo.chain == "regtest"
+        blockChainInfo.blocks >= 0
+        blockChainInfo.headers >= 0
+        blockChainInfo.bestBlockHash instanceof Sha256Hash
+        blockChainInfo.difficulty > 0
+        blockChainInfo.verificationProgress > 0
+        blockChainInfo.chainWork.length == 48
+    }
+}


### PR DESCRIPTION
This fixes the bug reported in PR #98 by @theborakompanioni 

Also add a functional test.

