### PR TITLE
cj-btc-json: remove ignoreUnknown annotation on defined JSON POJOs

### DIFF
--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/AddressGroupingItem.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/AddressGroupingItem.java
@@ -11,7 +11,6 @@ import java.util.List;
  * For listaddressgroupings response
  * Note: In the JSON response this is actually an array
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AddressGroupingItem {
     private final Address address;
     private final Coin balance;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockChainInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockChainInfo.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 /**
  * POJO for `getblockchaininfo` RPC response.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BlockChainInfo {
     private final String      chain;
     private final int         blocks;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/BlockInfo.java
@@ -13,7 +13,6 @@ import java.util.List;
 /**
  * BlockInfo POJO returned by GetBlockInfo
  */
-@JsonIgnoreProperties(ignoreUnknown=true)
 // "strippedsize" property added (present in Bitcoin 0.13)
 public class BlockInfo {
     public enum IncludeTxFlag {

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ChainTip.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ChainTip.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 /**
  *
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChainTip {
     private final int height;
     private final Sha256Hash hash;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/NetworkInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/NetworkInfo.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * POJO for `getnetworkinfo` RPC response.
  * Warning: `network` and `address` will be upgraded to POJOs in the future
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class NetworkInfo {
     private final int version;
     private final String subVersion;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/Outpoint.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/Outpoint.java
@@ -6,7 +6,6 @@ import org.bitcoinj.core.Sha256Hash;
 /**
  * Data class for Outpoint as used by RPC methods
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Outpoint {
     private final Sha256Hash txid;
     private final int        vout;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/RawTransactionInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/RawTransactionInfo.java
@@ -19,7 +19,6 @@ import java.util.List;
 /**
  * RawTransaction POJO
  */
-@JsonIgnoreProperties(ignoreUnknown=true)
 // "hash" property added (present in Bitcoin 0.13)
 public class RawTransactionInfo {
     public final String hex;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ReceivedByAddressInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ReceivedByAddressInfo.java
@@ -12,7 +12,6 @@ import java.util.List;
 /**
  *
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ReceivedByAddressInfo {
     public final Address address;
     public final Coin amount;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ServerInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/ServerInfo.java
@@ -10,7 +10,6 @@ import java.math.BigDecimal;
 /**
  * POJO for `getinfo` RPC response.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServerInfo {
     private final int version;
     private final int protocolversion;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  *
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class SignedRawTransaction {
     private final String hex;
     private final boolean complete;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutInfo.java
@@ -11,7 +11,6 @@ import java.util.Map;
 /**
  * Result of `gettxout`
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class TxOutInfo {
     private final Sha256Hash bestblock;
     private final int        confirmations;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
@@ -11,7 +11,6 @@ import org.bitcoinj.core.Sha256Hash;
  * Data class for UnspentOutput as returned by listUnspent RPC
  * Because the class is immutable we have to give Jackson some hints via annotations.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class UnspentOutput {
     private final Sha256Hash  txid;
     private final int         vout;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/WalletTransactionInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/WalletTransactionInfo.java
@@ -14,7 +14,6 @@ import java.util.List;
 /**
  * Detailed information about an in-wallet transaction (from gettransaction RPC)
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletTransactionInfo {
     private final Coin amount;
     private final Coin fee;
@@ -120,7 +119,6 @@ public class WalletTransactionInfo {
     public static class DetailList extends ArrayList<Detail> {
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Detail {
         private final String account;
         private final Address address;

--- a/consensusj-jsonrpc/src/main/java/org/consensusj/jsonrpc/AbstractRpcClient.java
+++ b/consensusj-jsonrpc/src/main/java/org/consensusj/jsonrpc/AbstractRpcClient.java
@@ -58,7 +58,6 @@ public abstract class AbstractRpcClient implements JacksonRpcClient {
         this.jsonRpcVersion = jsonRpcVersion;
         mapper = new ObjectMapper();
         // TODO: Provide external API to configure FAIL_ON_UNKNOWN_PROPERTIES
-        // TODO: Remove "ignore unknown" annotations on various POJOs that we've defined.
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         defaultType = mapper.getTypeFactory().constructType(Object.class);
     }


### PR DESCRIPTION
(This has been unnecessary since we added a global setting in the RPC client itself.)