### PR TITLE
cj-btc-daemon: add listunspent, signrawtransactionwithwallet, sendrawtransaction, etc.

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ '11', '17', '20' ]
+        java: [ '17', '20' ]
         distribution: ['temurin']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}

--- a/README.adoc
+++ b/README.adoc
@@ -191,7 +191,7 @@ We have completed refactoring all modules into the new `org.consensusj` package 
 | Bitcoin Service-Layer objects - compatible with `jakarta.inject` (https://jcp.org/en/jsr/detail?id=330[JSR-330])
 
 |<<cj-btc-jsonrpc-integ-test,cj-btc-jsonrpc-integ-test>>
-| 11
+| *17*
 |n/a
 |Bitcoin JSON-RPC integration tests (RegTest)
 
@@ -419,7 +419,7 @@ These sample Spock "feature tests" show the RPC client in action and are from th
 http://javamoney.github.io[JavaMoney] (also known as http://javamoney.github.io/api.html[JSR 354]) is the new Java Standard for advanced and flexible currency handling on the Java platform.
 
 [quote, JavaMoney Web Site]
-JSR 354 provides a portable and extensible framework for handling of Money & Currency. The API models monetary amounts and currencies in a platform independent and portable way, including well defined extension points.
+JSR 354 provides a portable and extensible framework for handling of Money & Currency. The API models monetary amounts and currencies in a platform independent and portable way, including well-defined extension points.
 
 Support for virtual currencies is one of the key design goals in the specification. The `consensusj-currency` module allows Bitcoin to
 be used by standard Java APIs in the same ways as fiat currencies.

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/service/SignTransactionService.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/service/SignTransactionService.java
@@ -1,0 +1,41 @@
+package org.consensusj.bitcoinj.service;
+
+import org.bitcoinj.base.Address;
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
+import org.consensusj.bitcoinj.signing.SigningRequest;
+import org.consensusj.bitcoinj.signing.TransactionInputData;
+import org.consensusj.bitcoinj.signing.TransactionOutputData;
+import org.consensusj.bitcoinj.signing.TransactionSigner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A wallet-level service that can complete and sign transactions.
+ */
+public interface SignTransactionService extends TransactionSigner {
+
+    /**
+     * Create and sign a transaction to send coins to the specified address. Implements the transaction-building
+     * and signing portion of `sendtoaddress` RPC.
+     * @param toAddress destination address
+     * @param amount amount to send
+     * @return a future signed transaction
+     */
+    CompletableFuture<Transaction> signSendToAddress(Address toAddress, Coin amount) throws IOException, InsufficientMoneyException;
+
+    /**
+     * Create a signing request, given a list of inputs, a list of outputs and a change address. Calculates
+     * the fee, adds a change output, and returns a completed signing request.
+     * @param network network (shouldn't be needed, but is for now)
+     * @param inputUtxos list of available UTXOs
+     * @param outputs Outputs to send to
+     * @param changeAddress address that will receive change
+     * @return a completed transaction signing request
+     */
+    SigningRequest createBitcoinSigningRequest(Network network, List<? super TransactionInputData> inputUtxos, List<TransactionOutputData> outputs, Address changeAddress) throws InsufficientMoneyException;
+}

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/BaseTransactionSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/BaseTransactionSigner.java
@@ -1,0 +1,60 @@
+package org.consensusj.bitcoinj.signing;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.params.BitcoinNetworkParams;
+import org.bitcoinj.wallet.DeterministicKeyChain;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+/**
+ * A template interface, implementations need only implement {@link #keyForInput(TransactionInputData)}.
+ * The {@link HDKeychainSigner} implementation can sign transactions using a <b>bitcoinj</b> {@link DeterministicKeyChain}.
+ */
+public interface BaseTransactionSigner extends TransactionSigner {
+    /**
+     * Create a signed bitcoinj transaction from the signing request
+     * <p>
+     * @param request Signing request with data for all inputs and all outputs
+     * @return A signed transaction (should be treated as immutable)
+     */
+    @Override
+    default CompletableFuture<Transaction> signTransaction(SigningRequest request) {
+        NetworkParameters params = BitcoinNetworkParams.fromID(request.networkId());
+        // Create a new, empty (mutable) bitcoinj transaction
+        Transaction transaction = new Transaction(params);
+
+        // For each output in the signing request, add an output to the bitcoinj transaction
+        // TODO: Transaction validation
+        request.outputs().forEach(
+                output -> transaction.addOutput(output.toMutableOutput(params.network()))
+        );
+
+        // For each address in the input list, add a signed input to the bitcoinj transaction
+        request.inputs().forEach(
+                input -> addSignedInput(transaction, input, () -> new RuntimeException("Unsupported transaction input"))
+        );
+
+        return CompletableFuture.completedFuture(transaction);
+    }
+
+    /**
+     *
+     * @param tx Mutable transaction currently being built
+     * @param in The transaction input data
+     * @param exceptionSupplier exception to throw if key is not available.
+     */
+    default void addSignedInput(Transaction tx, TransactionInputData in, Supplier<? extends RuntimeException> exceptionSupplier) {
+        tx.addSignedInput(in.toOutPoint(tx.getParams().network()), in.script(), in.amount(), keyForInput(in).orElseThrow(exceptionSupplier), Transaction.SigHash.ALL, false);
+    }
+
+    /**
+     * Return an ECKey, if available for the provided input
+     * @param input A transaction input
+     * @return The ECKey or empty
+     */
+    Optional<ECKey> keyForInput(TransactionInputData input);
+}

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
@@ -3,6 +3,9 @@ package org.consensusj.bitcoinj.signing;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutput;
 
 import java.util.Collections;
 import java.util.List;
@@ -66,5 +69,25 @@ public class DefaultSigningRequest implements SigningRequest {
     @Override
     public List<TransactionOutputData> outputs() {
         return outputs;
+    }
+
+    /**
+     * bitcoinj signing uses (currently) mutable transaction objects, this
+     * convenience method will create one if you want to use bitcoinj to sign this request.
+     * @return an unsigned bitcoinj transaction
+     */
+    public Transaction toUnsignedTransaction() {
+        NetworkParameters params = NetworkParameters.of(network);
+        Transaction utx = new Transaction(params);
+        this.inputs().forEach(in ->
+                utx.addInput(new TransactionInput(params,
+                        utx,
+                        in.script().getProgram())));
+        this.outputs().forEach(out ->
+                utx.addOutput(new TransactionOutput(params,
+                        utx,
+                        out.amount(),
+                        out.script().getProgram())));
+        return utx;
     }
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/ECKeySigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/ECKeySigner.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  * A simple transaction signer using a single ECKey that can sign either
  * {@link ScriptType#P2PKH} or {@link ScriptType#P2WPKH} transactions.
  */
-public class ECKeySigner implements TransactionSigner {
+public class ECKeySigner implements BaseTransactionSigner {
     private final ECKey ecKey;
 
     /**

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
  * A "signing wallet"  that uses a {@link DeterministicKeyChain} to
  * sign {@link SigningRequest}s.
  */
-public class HDKeychainSigner implements TransactionSigner {
+public class HDKeychainSigner implements BaseTransactionSigner {
     private final DeterministicKeyChain keyChain;
 
     public HDKeychainSigner(DeterministicKeyChain keyChain) {

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
@@ -3,6 +3,7 @@ package org.consensusj.bitcoinj.signing;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.script.Script;
 
 /**
@@ -17,4 +18,13 @@ public interface TransactionInputData {
      * @return A Transaction "outpoint" pointing to the output corresponding to this input.
      */
     TransactionOutPoint toOutPoint(Network network);
+
+    /**
+     * Create a transaction input from an unspent transaction output.
+     * @param out An unspent transaction output
+     * @return transaction input data
+     */
+    static TransactionInputDataImpl fromTxOut(TransactionOutput out) {
+        return new TransactionInputDataImpl(out.getParentTransactionHash(), out.getIndex(), out.getValue(), out.getScriptPubKey());
+    }
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputDataImpl.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputDataImpl.java
@@ -21,13 +21,25 @@ public class TransactionInputDataImpl implements TransactionInputData {
     private final long amount;
     private final Script script;
 
+    /**
+     * @param txId parent txId (shouldn't be needed but Transaction.addSignedInput currently needs an Outpoint)
+     * @param index index of unspent output
+     * @param amount amount of unspent output
+     * @param script
+     */
     public TransactionInputDataImpl(Sha256Hash txId, long index, Coin amount, Script script) {
         this.txId = txId;
         this.index = index;
-        this.amount = amount.getValue();
+        this.amount = amount != null ? amount.getValue() : 0;        // TODO: Throw when amount is null?
         this.script = script;
     }
 
+    /**
+     * @param txId parent txId (shouldn't be needed but Transaction.addSignedInput currently needs an Outpoint)
+     * @param index index of unspent output
+     * @param amount amount of unspent output
+     * @param address
+     */
     public TransactionInputDataImpl(Sha256Hash txId, long index, Coin amount, Address address) {
         this(txId, index, amount, ScriptBuilder.createOutputScript(address));
     }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputDataScript.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputDataScript.java
@@ -1,0 +1,27 @@
+package org.consensusj.bitcoinj.signing;
+
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.script.Script;
+
+/**
+ *
+ */
+public class TransactionOutputDataScript implements TransactionOutputData {
+    private final Coin amount;
+    private final Script script;
+
+    public TransactionOutputDataScript(Coin amount, Script script) {
+        this.amount = amount;
+        this.script = script;
+    }
+
+    @Override
+    public Coin amount() {
+        return amount;
+    }
+
+    @Override
+    public Script script() {
+        return script;
+    }
+}

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionSigner.java
@@ -1,57 +1,21 @@
 package org.consensusj.bitcoinj.signing;
 
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.params.BitcoinNetworkParams;
+import org.bitcoinj.wallet.DeterministicKeyChain;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 
 /**
- *
+ * A low-level transaction signing interface that can sign a {@link SigningRequest} that is a complete
+ * transaction that only needs signatures. The {@link HDKeychainSigner} implementation can sign transactions
+ * using a <b>bitcoinj</b> {@link DeterministicKeyChain}.
  */
 public interface TransactionSigner {
     /**
-     * Create a signed bitcoinj transaction from the signing request
-     * <p>
+     * Create a signed bitcoinj transaction from the signing request. This is asynchronous because
+     * user (or other) confirmation may be required.
      * @param request Signing request with data for all inputs and all outputs
      * @return A signed transaction (should be treated as immutable)
      */
-    default CompletableFuture<Transaction> signTransaction(SigningRequest request) {
-        NetworkParameters params = BitcoinNetworkParams.fromID(request.networkId());
-        // Create a new, empty (mutable) bitcoinj transaction
-        Transaction transaction = new Transaction(params);
-
-        // For each output in the signing request, add an output to the bitcoinj transaction
-        // TODO: Transaction validation
-        request.outputs().forEach(
-                output -> transaction.addOutput(output.toMutableOutput(params.network()))
-        );
-
-        // For each address in the input list, add a signed input to the bitcoinj transaction
-        request.inputs().forEach(
-                input -> addSignedInput(transaction, input, () -> new RuntimeException("Unsupported transaction input"))
-        );
-
-        return CompletableFuture.completedFuture(transaction);
-    }
-
-    /**
-     *
-     * @param tx Mutable transaction currently being built
-     * @param in The transaction input data
-     * @param exceptionSupplier exception to throw if key is not available.
-     */
-    default void addSignedInput(Transaction tx, TransactionInputData in, Supplier<? extends RuntimeException> exceptionSupplier) {
-        tx.addSignedInput(in.toOutPoint(tx.getParams().network()), in.script(), in.amount(), keyForInput(in).orElseThrow(exceptionSupplier), Transaction.SigHash.ALL, false);
-    }
-
-    /**
-     * Return an ECKey, if available for the provided input
-     * @param input A transaction input
-     * @return The ECKey or empty
-     */
-    Optional<ECKey> keyForInput(TransactionInputData input);
+    CompletableFuture<Transaction> signTransaction(SigningRequest request);
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/wallet/BipStandardDeterministicKeyChain.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/wallet/BipStandardDeterministicKeyChain.java
@@ -4,7 +4,6 @@ import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.HDPath;
@@ -45,6 +44,7 @@ public class BipStandardDeterministicKeyChain extends DeterministicKeyChain {
 
     /**
      * Construct a BipStandardDeterministicKeyChain from a DeterministicKeyChain
+     * THIS IS NOT A WRAPPER, BUT A COPY -- THIS IS PROBABLY NOT WHAT WE WANT!
      * @param hdChain existing DeterministicKeyChain
      * @param network network (used for constructing addresses)
      */
@@ -57,16 +57,6 @@ public class BipStandardDeterministicKeyChain extends DeterministicKeyChain {
         this.network = network;
         pathReceiving = super.getAccountPath().extend(DeterministicKeyChain.EXTERNAL_SUBPATH);
         pathChange = super.getAccountPath().extend(DeterministicKeyChain.INTERNAL_SUBPATH);
-    }
-
-    @Deprecated
-    public BipStandardDeterministicKeyChain(DeterministicSeed seed, ScriptType outputScriptType, NetworkParameters netParams) {
-        this(seed, outputScriptType, netParams.network());
-    }
-
-    @Deprecated
-    public BipStandardDeterministicKeyChain(DeterministicKeyChain hdChain, NetworkParameters netParams) {
-        this(hdChain, netParams.network());
     }
 
     public Address addressFromKey(ECKey key) {

--- a/cj-btc-daemon/build.gradle
+++ b/cj-btc-daemon/build.gradle
@@ -30,6 +30,9 @@ configurations {
     compileClasspath {
         resolutionStrategy.force 'org.slf4j:slf4j-api:1.7.36'
     }
+    runtimeClasspath {
+        resolutionStrategy.force 'org.slf4j:slf4j-api:1.7.36'
+    }
 }
 
 dependencies {

--- a/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/BitcoinFactory.java
+++ b/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/BitcoinFactory.java
@@ -37,7 +37,8 @@ public class BitcoinFactory {
                     : AppDataDirectory.get(config.walletBaseName()).toFile()       // null -> app data dir
                 : config.dataDir().toFile();                                       // non-null -> use Path from config
         log.info("Returning WalletAppKit bean, wallet directory: {}, prefix: {}", dataDirectory.getAbsolutePath(), filePrefix);
-        return new WalletAppKit((BitcoinNetwork) config.network(), ScriptType.P2PKH, KeyChainGroupStructure.BIP32, dataDirectory, filePrefix);
+        System.out.println("Creating WalletAppKit for " + config.network().id());
+        return new WalletAppKit((BitcoinNetwork) config.network(), ScriptType.P2PKH, KeyChainGroupStructure.BIP43, dataDirectory, filePrefix);
     }
 
     @Singleton

--- a/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/JsonRpcController.java
+++ b/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/JsonRpcController.java
@@ -1,26 +1,16 @@
 package org.consensusj.daemon.micronaut;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import org.consensusj.bitcoin.json.pojo.BlockChainInfo;
-import org.consensusj.bitcoin.json.pojo.BlockInfo;
-import org.consensusj.bitcoin.json.pojo.ServerInfo;
 import io.micronaut.context.annotation.Context;
-import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
-import org.bitcoinj.base.Sha256Hash;
-import org.consensusj.bitcoin.services.WalletAppKitService;
 import org.consensusj.jsonrpc.JsonRpcRequest;
 import org.consensusj.jsonrpc.JsonRpcResponse;
 import org.consensusj.jsonrpc.JsonRpcService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -28,22 +18,6 @@ import java.util.concurrent.CompletableFuture;
  * Here we're using Micronaut annotations to wrap the JsonRpcService
  * in an HTTP environment and to serialize JSON to and from Java POJOs.
  */
-@TypeHint(
-        value = {
-                PropertyNamingStrategies.UpperCamelCaseStrategy.class,
-                ArrayList.class,
-                LinkedHashMap.class,
-                HashSet.class,
-                JsonRpcRequest.class,
-                JsonRpcResponse.class,
-                ServerInfo.class,
-                BlockInfo.class,
-                BlockChainInfo.class,
-                Sha256Hash.class,
-                WalletAppKitService.class
-        },
-        accessType = {TypeHint.AccessType.ALL_DECLARED_CONSTRUCTORS, TypeHint.AccessType.ALL_DECLARED_METHODS}
-)
 @Controller("/")
 @Context
 public class JsonRpcController {

--- a/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/MicronautWalletAppKitService.java
+++ b/cj-btc-daemon/src/main/java/org/consensusj/daemon/micronaut/MicronautWalletAppKitService.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 
+// TODO: Rather than subclass WalletAppKitService there should be a RPCServerShutdown class or interface
+// that is passed in to  WalletAppKitService that it can all when `stop` is called.
 /**
  * Subclass of {@link WalletAppKitService} that implements the {@code stop} JSON-RPC method using
  * Micronaut {@link EmbeddedServer#stop()}

--- a/cj-btc-daemon/src/main/resources/application-test.toml
+++ b/cj-btc-daemon/src/main/resources/application-test.toml
@@ -1,0 +1,15 @@
+micronaut.application.name = 'cjbitcoind'
+
+# network-id must specify a valid org.bitcoinj.base.BitcoinNetwork either by
+# a lowercase name ("mainnet", "testnet", "signet", or "regtest") or by
+# an ID ("org.bitcoin.production", "org.bitcoin.testnet", etc.)
+cjbitcoind.config.network-id = "regtest"
+
+# The server port for listening for JSON-RPC and REST queries
+cjbitcoind.config.server-port = 8080
+
+# path to wallet data-directory, if `null`, defaults to AppDataDirectory for appName
+#cjbitcoind.config.data-dir
+
+# Base name for wallet files, e.g. CJBitcoinDaemon-mainnet.wallet, CJBitcoinDaemon-mainnet.spvchain
+cjbitcoind.config.wallet-base-name = "CJBitcoinDaemon"

--- a/cj-btc-daemon/src/main/resources/logback.xml
+++ b/cj-btc-daemon/src/main/resources/logback.xml
@@ -13,6 +13,14 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
+    <logger name="org.bitcoinj.core" level="warn" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="org.bitcoinj.net" level="error" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>

--- a/cj-btc-daemon/src/test/groovy/org/consensusj/daemon/micronaut/BitcoinDaemonConfigSpec.groovy
+++ b/cj-btc-daemon/src/test/groovy/org/consensusj/daemon/micronaut/BitcoinDaemonConfigSpec.groovy
@@ -5,7 +5,7 @@ import org.bitcoinj.base.BitcoinNetwork
 import spock.lang.Specification
 
 /**
- * Test the configuration record
+ * Test the configuration record. It should be loaded from {@code resources/application-test.toml}.
  */
 class BitcoinDaemonConfigSpec extends Specification {
     void "test default BitcoinDaemon configuration"() {
@@ -17,8 +17,8 @@ class BitcoinDaemonConfigSpec extends Specification {
 
         then:
         config.walletBaseName() == "CJBitcoinDaemon"
-        config.networkId() == "testnet"
-        config.network() == BitcoinNetwork.TESTNET
+        config.networkId() == "regtest"
+        config.network() == BitcoinNetwork.REGTEST
         config.serverPort() == 8080
 
         cleanup:

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/HexUtil.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/HexUtil.java
@@ -8,6 +8,7 @@ import java.util.Formatter;
 public class HexUtil {
     /**
      * Converts a hex-encoded string into a byte array.
+     * If you are on Java 17 or later you should use {@code HexFormat}
      *
      * @param s A string to convert
      * @return The byte array

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
@@ -1,0 +1,55 @@
+package org.consensusj.bitcoin.json.pojo;
+
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Sha256Hash;
+
+/**
+ *
+ */
+public class PrevTxOutInfo implements UtxoInfo {
+    private final Sha256Hash txId;
+    private final int vout;
+    private final String scriptPubKey;
+    private final String redeemScript;
+    private final String witnessScript;
+    private final Coin amount;
+
+    public PrevTxOutInfo(Sha256Hash txId, int vout, String scriptPubKey, String redeemScript, String witnessScript, Coin amount) {
+        this.txId = txId;
+        this.vout = vout;
+        this.scriptPubKey = scriptPubKey;
+        this.redeemScript = redeemScript;
+        this.witnessScript = witnessScript;
+        this.amount = amount;
+    }
+
+    @Override
+    public Sha256Hash getTxid() {
+        return txId;
+    }
+
+    @Override
+    public int getVout() {
+        return vout;
+    }
+
+    @Override
+    public String getScriptPubKey() {
+        return scriptPubKey;
+    }
+
+    @Override
+    public String getRedeemScript() {
+        return redeemScript;
+    }
+
+    @Override
+    public String getWitnessScript() {
+        return witnessScript;
+    }
+
+    @Override
+    public Coin getAmount() {
+        return amount;
+    }
+}

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
@@ -1,25 +1,34 @@
 package org.consensusj.bitcoin.json.pojo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.bitcoinj.core.Transaction;
+import org.consensusj.bitcoin.json.conversion.HexUtil;
 
 /**
  *
  */
 public class SignedRawTransaction {
-    private final String hex;
+    private final byte[] bytes;
     private final boolean complete;
+
+    public static SignedRawTransaction of(Transaction transaction) {
+        return new SignedRawTransaction(transaction.bitcoinSerialize(), true);
+    }
 
     @JsonCreator
     public SignedRawTransaction(@JsonProperty("hex")        String   hex,
                                 @JsonProperty("complete")   boolean  complete) {
-        this.hex = hex;
+        this(HexUtil.hexStringToByteArray(hex), complete);
+    }
+
+    private SignedRawTransaction(byte[] bytes, boolean complete) {
+        this.bytes = bytes;
         this.complete = complete;
     }
 
     public  String getHex() {
-        return hex;
+        return HexUtil.bytesToHexString(bytes);
     }
 
     public boolean isComplete() {

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
@@ -10,7 +10,7 @@ import org.bitcoinj.base.Sha256Hash;
  * Data class for UnspentOutput as returned by listUnspent RPC
  * Because the class is immutable we have to give Jackson some hints via annotations.
  */
-public class UnspentOutput {
+public class UnspentOutput implements UtxoInfo {
     private final Sha256Hash  txid;
     private final int         vout;
     private final Address     address;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UtxoInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UtxoInfo.java
@@ -1,0 +1,22 @@
+package org.consensusj.bitcoin.json.pojo;
+
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Sha256Hash;
+
+/**
+ * Interface for commonly-used UTXO information, for example the {@code prevtxs} parameter of
+ * the {@code signrawtransactionwithwallet} JSON-RPC request.
+ */
+public interface UtxoInfo {
+    Sha256Hash getTxid();
+
+    int getVout();
+
+    String getScriptPubKey();
+
+    String getRedeemScript();
+
+    String getWitnessScript();
+
+    Coin getAmount();
+}

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/rpc/BitcoinJsonRpc.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/rpc/BitcoinJsonRpc.java
@@ -1,31 +1,66 @@
 package org.consensusj.bitcoin.json.rpc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.consensusj.bitcoin.json.pojo.BlockChainInfo;
 import org.consensusj.bitcoin.json.pojo.NetworkInfo;
 import org.bitcoinj.base.Sha256Hash;
+import org.consensusj.bitcoin.json.pojo.SignedRawTransaction;
+import org.consensusj.bitcoin.json.pojo.UnspentOutput;
 
-import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Standard Bitcoin JSON-RPC service
+ * Standard Bitcoin JSON-RPC API RPCs. For now, this is a subset implementation that is not fully-compatible
+ * with Bitcoin Core. Some parameters are missing and the defined response types may omit some properties.
+ * <p>
+ * All parameters are object types so {@code null} can be used to represent an omitted optional parameter.
  */
 public interface BitcoinJsonRpc {
-    CompletableFuture<String> help();
-    CompletableFuture<String> stop();
-    CompletableFuture<Integer> getblockcount();
+    int DEFAULT_MIN_CONF = 1;
+    int DEFAULT_MAX_CONF = 9999999;
+
+    /* == Blockchain == */
+
     CompletableFuture<Sha256Hash> getbestblockhash();
-    CompletableFuture<JsonNode> getblockheader(String blockHashString, Boolean verbose);
-// TODO: Support Sha256Hash type in request params: see Issue #104
+    // TODO: Support Sha256Hash type in request params: see Issue #104
 //  CompletableFuture<Object> getblock(Sha256Hash blockHash, Integer verbosity);
     CompletableFuture<JsonNode> getblock(String blockHashString, Integer verbosity);
-    CompletableFuture<Sha256Hash> getblockhash(Integer blockNumber);
-    CompletableFuture<Integer> getconnectioncount();
     CompletableFuture<BlockChainInfo> getblockchaininfo();
+    CompletableFuture<Integer> getblockcount();
+    CompletableFuture<Sha256Hash> getblockhash(Integer blockNumber);
+    CompletableFuture<JsonNode> getblockheader(String blockHashString, Boolean verbose);
+
+    /* == Control == */
+
+    CompletableFuture<String> help();
+    CompletableFuture<String> stop();
+
+    /* == Network == */
+
+    CompletableFuture<Integer> getconnectioncount();
     CompletableFuture<NetworkInfo> getnetworkinfo();
-    CompletableFuture<String> getnewaddress();
-    CompletableFuture<String> getbalance();
+
+    /* == Rawtransactions == */
+
+    CompletableFuture<String> createrawtransaction(List<Map<String, Object>> inputs, List<Map<String, String>> outputs);
+    CompletableFuture<Sha256Hash> sendrawtransaction(String hex);
+
+    /* == Wallet == */
+
+    CompletableFuture<Coin> getbalance();
+    CompletableFuture<Address> getnewaddress();
+    CompletableFuture<List<UnspentOutput>> listunspent(Integer minConf, Integer maxConf, List<String> addresses, Boolean includeUnsafe);
     CompletableFuture<Sha256Hash> sendtoaddress(String address, Double amount);
+
+    // TODO: Add prevtxs and sighashtype parameters
+    /**
+     * Currently all UTXOs must be present in the wallet and {@code sighashtype} defaults to {@code "ALL"}.
+     * @param hex hex-encoded unsigned raw transaction
+     * @return An object containing the signed transaction
+     */
+    CompletableFuture<SignedRawTransaction> signrawtransactionwithwallet(String hex);
 }

--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -6,6 +6,7 @@ configurations {
 dependencies {
     testImplementation project(':cj-btc-jsonrpc-gvy')
     testImplementation project(':cj-btc-json')
+    testImplementation project(':cj-btc-services')     // To test WalletAppKitService
     testImplementation project(':cj-bitcoinj-util')     // For BlockUtils
     testImplementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
     testImplementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
@@ -84,5 +85,6 @@ task regTest(type: Test) {
     include 'org/consensusj/bitcoin/rpc/**',
             'org/consensusj/bitcoin/integ/bitcoinj/**',
             'org/consensusj/bitcoin/integ/funding/**',
+            'org/consensusj/bitcoin/integ/services/**',
             'org/consensusj/bitcoin/integ/java/**'
 }

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
@@ -1,0 +1,178 @@
+package org.consensusj.bitcoin.integ.services
+
+import com.fasterxml.jackson.databind.JsonNode
+import groovy.util.logging.Slf4j
+import org.bitcoinj.base.Address
+import org.bitcoinj.base.AddressParser
+import org.bitcoinj.base.BitcoinNetwork
+import org.bitcoinj.base.DefaultAddressParser
+import org.bitcoinj.base.ScriptType
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.crypto.ECKey
+import org.bitcoinj.script.Script
+import org.bitcoinj.script.ScriptBuilder
+import org.consensusj.bitcoin.json.conversion.HexUtil
+import org.consensusj.bitcoin.services.WalletAppKitService
+import org.consensusj.bitcoin.test.BaseRegTestSpec
+import org.consensusj.bitcoinj.signing.DefaultSigningRequest
+import spock.lang.Shared
+import spock.lang.Stepwise
+
+import java.nio.ByteBuffer
+
+/**
+ * Test WalletAppKitService on RegTest through a series of transactions.
+ */
+@Slf4j
+@Stepwise
+class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
+    private final hexFormatter = HexFormat.of();
+    
+    /** The WalletAppKitService under test */
+    @Shared WalletAppKitService appKitService;
+
+    @Shared Address spvWalletAddress
+
+    def setupSpec() {
+        appKitService = WalletAppKitService.createTemporary(BitcoinNetwork.REGTEST, ScriptType.P2PKH, "cj-btc-services-unittest")
+        appKitService.start()
+    }
+
+    def 'loaded correctly'() {
+        expect:
+        appKitService != null
+        appKitService.network() == BitcoinNetwork.REGTEST
+    }
+
+    def 'get an address'() {
+        when:
+        spvWalletAddress = appKitService.getnewaddress().join()
+
+        then:
+        spvWalletAddress != null
+    }
+
+    def 'get some coins and send money to an address in appKitService'() {
+        when:
+        log.warn("spvWalletAddress: {}", spvWalletAddress)
+        var txId = requestBitcoin(spvWalletAddress, 2.btc)
+        generateBlocks(1)
+        waitForWalletSync()
+
+        then:
+        txId != null
+
+        when:
+        var balance = appKitService.getbalance().join()
+
+        then:
+        balance >= 1.btc
+
+        when:
+        var list = appKitService.listunspent(null, null, List.of(spvWalletAddress.toString()), false).join()
+
+        then:
+        list != null
+        list.size() == 1
+        list[0].amount == 2.btc
+    }
+
+    def 'build and sign a raw transaction using appKitService'() {
+        given:
+        var toAddr = new ECKey().toAddress(ScriptType.P2PKH, network)
+
+        when: "we list unspent outputs go get a utxo"
+        var list = appKitService.listunspent(null, null, List.of(spvWalletAddress.toString()), false).join()
+
+        then:
+        list != null
+        list.size() == 1
+        list[0].amount == 2.btc
+        list[0].scriptPubKey == hexFormatter.formatHex(ScriptBuilder.createP2PKHOutputScript(spvWalletAddress.hash).getProgram())
+
+        when: "we build an unsigned tx"
+        var utxo = list[0]
+        var funds = utxo.amount
+        var sendAmount = 0.5.btc
+        var signingRequest = new DefaultSigningRequest(network)
+                .addInput(new Script(HexFormat.of().parseHex(utxo.getScriptPubKey())), utxo.amount, utxo.txid, utxo.vout)
+                .addOutput(toAddr, sendAmount)
+                .addOutput(spvWalletAddress, funds - (sendAmount + 0.1.btc))   // Change
+        var utx = signingRequest.toUnsignedTransaction()
+
+        then:
+        utx.getOutputSum() >= 0.9.btc
+
+        when: "we send the utx to appKitService for signing"
+        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.bitcoinSerialize())).join()
+
+        then:
+        result != null
+        result.isComplete()
+        result.getHex() != null
+
+        when: "we deserialize the signed tx"
+        var signed = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
+
+        then:
+        signed != null
+        signed.getOutputSum() >= 0.9.btc
+    }
+
+    def 'create raw transaction using appKitService.createrawtransaction'() {
+        given:
+        var toAddr = new ECKey().toAddress(ScriptType.P2PKH, network)
+
+        when: "we list unspent outputs go get a utxo"
+        var list = appKitService.listunspent(null, null, List.of(spvWalletAddress.toString()), false).join()
+
+        then:
+        list != null
+        list.size() == 1
+        list[0].amount >= 1.btc
+        list[0].scriptPubKey == hexFormatter.formatHex(ScriptBuilder.createP2PKHOutputScript(spvWalletAddress.hash).getProgram())
+
+        when: "we build an unsigned tx"
+        var utxo = list[0]
+        var funds = utxo.amount
+        var sendAmount = 0.5.btc
+        Map <String, Object> inp = Map.of("txid", list[0].getTxid().toString(), "vout", list[0].getVout())
+        Map<String, String> toOutput = Map.of(toAddr.toString(), sendAmount.toPlainString())
+        Map<String, String> changeOutput = Map.of(spvWalletAddress.toString(), (funds - (sendAmount + 0.1.btc)).toPlainString());
+        var hex = appKitService.createrawtransaction(List.of(inp), List.of(toOutput, changeOutput)).join()
+        var utx = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(hex)));
+
+        then:
+        utx.getOutputSum() >= 0.9.btc
+
+        when: "we send the utx to appKitService for signing"
+        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.bitcoinSerialize())).join()
+
+        then:
+        result != null
+        result.isComplete()
+        result.getHex() != null
+
+        when: "we deserialize the signed tx"
+        var signed = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
+
+        then:
+        signed != null
+        signed.getOutputSum() >= 0.9.btc
+    }
+
+
+
+    /**
+     * Wait for the bitcoinj wallet to sync with the Bitcoin Core blockchain
+     */
+    void waitForWalletSync() {
+        int walletHeight, serverHeight
+        while ( (walletHeight = appKitService.getblockcount().join()) < (serverHeight = client.getBlockCount()) ) {
+            // TODO: Figure out a way to do this without polling and sleeping
+            println "walletHeight < serverHeight: ${walletHeight} < ${serverHeight} -- Waiting..."
+            Thread.sleep(100)
+        }
+        println "walletHeight: ${walletHeight}, serverHeight: ${serverHeight}"
+    }
+}

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinExtendedClientSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinExtendedClientSpec.groovy
@@ -19,6 +19,11 @@ class BitcoinExtendedClientSpec extends Specification {
     @Shared
     FundingSource funder
 
+    def "There is well-known RegTestMiningAddress"() {
+        expect:
+        client.getRegTestMiningAddress() == BitcoinExtendedClient.DEFAULT_REGTEST_MINING_ADDRESS
+    }
+
     def "Can create a funded address and send coins with sendBitcoin()"() {
         given: "a client, a source of funds, and a blockchain environment"
         RegTestEnvironment chainEnv = new RegTestEnvironment(client)

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -2,6 +2,7 @@ package org.consensusj.bitcoin.jsonrpc;
 
 import com.fasterxml.jackson.databind.JavaType;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.consensusj.bitcoin.json.pojo.AddressInfo;
@@ -43,12 +44,12 @@ import java.util.stream.Collectors;
 public class BitcoinExtendedClient extends BitcoinClient {
     private static final Logger log = LoggerFactory.getLogger(BitcoinExtendedClient.class);
 
+    public static final Address DEFAULT_REGTEST_MINING_ADDRESS = new DefaultAddressParser().parseAddressAnyNetwork("mwQA8f4pH23BfHyy4zf8mgAyeNu5uoy6GU");
     private static final BigInteger NotSoPrivatePrivateInt = new BigInteger(1, Hex.decode("180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19"));
     private static final String RegTestMiningAddressLabel = "RegTestMiningAddress";
     public static final String REGTEST_WALLET_NAME = "consensusj-regtest-wallet";
     private boolean regTestWalletInitialized = false;
     private /* lazy */ Address regTestMiningAddress;
-
 
     public final Coin stdTxFee = Coin.valueOf(10000);
     public final Coin stdRelayTxFee = Coin.valueOf(1000);

--- a/cj-btc-services/build.gradle
+++ b/cj-btc-services/build.gradle
@@ -10,6 +10,7 @@ tasks.withType(JavaCompile) {
 
 dependencies {
     api project(':cj-btc-json')
+    implementation project(':cj-bitcoinj-util')
     api 'jakarta.inject:jakarta.inject-api:2.0.1'
     implementation 'jakarta.annotation:jakarta.annotation-api:2.0.0'
 }

--- a/cj-btc-services/src/main/java/org/consensusj/bitcoin/services/WalletAppKitService.java
+++ b/cj-btc-services/src/main/java/org/consensusj/bitcoin/services/WalletAppKitService.java
@@ -3,17 +3,30 @@ package org.consensusj.bitcoin.services;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bitcoinj.base.Address;
+import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.ProtocolException;
+import org.bitcoinj.core.TransactionBroadcast;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.DeterministicKey;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.wallet.KeyChain;
+import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.consensusj.bitcoin.json.conversion.HexUtil;
 import org.consensusj.bitcoin.json.conversion.RpcServerModule;
 import org.consensusj.bitcoin.json.pojo.BlockChainInfo;
 import org.consensusj.bitcoin.json.pojo.BlockInfo;
 import org.consensusj.bitcoin.json.pojo.NetworkInfo;
+import org.consensusj.bitcoin.json.pojo.SignedRawTransaction;
+import org.consensusj.bitcoin.json.pojo.UnspentOutput;
 import org.consensusj.bitcoin.json.rpc.BitcoinJsonRpc;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Block;
@@ -24,6 +37,11 @@ import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.store.BlockStoreException;
+import org.consensusj.bitcoinj.signing.DefaultSigningRequest;
+import org.consensusj.bitcoinj.signing.SigningRequest;
+import org.consensusj.bitcoinj.signing.TransactionInputData;
+import org.consensusj.bitcoinj.signing.TransactionOutputData;
+import org.consensusj.bitcoinj.signing.TransactionOutputDataScript;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,8 +51,14 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
 import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -51,19 +75,35 @@ public class WalletAppKitService implements BitcoinJsonRpc, Closeable {
     // server version, placeholder for now (returned in `getnetworkinfo`)
     private static final int version = 1;
     private static final String helpString = """
-            getbalance
-            getbestblockhash
-            getblock hash verbosity(0,1,2)
-            getblockchaininfo
-            getblockcount
-            getblockhash height [TBD]
-            getblockheader hash verbose(boolean)
-            getconnectioncount
-            getnetworkinfo
-            help
-            sendtoaddress "address" amount [TBD]
-            stop
-    """;
+== Blockchain ==
+getbestblockhash
+getblock hash verbosity(0,1,2)
+getblockchaininfo
+getblockcount
+getblockhash height [TBD]
+getblockheader hash verbose(boolean)
+
+== Control ==
+help
+stop
+
+== Network ==
+getconnectioncount
+getnetworkinfo
+
+== Rawtransactions ==
+createrawtransaction [{"txid":"hex","vout":n},...] [{"address":amount},...]
+sendrawtransaction hex
+
+== Wallet ==
+getbalance
+getnewaddress
+listunspent minConf maxConf addresses include-unsafe
+sendtoaddress address amount
+signrawtransactionwithwallet hex
+""";
+
+    protected final HexFormat hexFormat = HexFormat.of();
 
     protected final BitcoinNetwork network;
     protected final WalletAppKit kit;
@@ -75,8 +115,32 @@ public class WalletAppKitService implements BitcoinJsonRpc, Closeable {
     private BigDecimal verificationProgress = new BigDecimal(0);
     private byte[] chainWork = new byte[]{0x00, 0x00};
 
+    private static final AddressParser parser = new DefaultAddressParser();
+    private WalletSigningService signingService;
+
     /**
-     * Construct from an (unstarted) {@link WalletAppKit} instance.
+     * Create an instance in a temporary directory. Useful for testing.
+     * @param network network to operate on
+     * @param scriptType script type for wallet
+     * @param walletBaseName base name for the two wallet files
+     * @return an un-started instance (use {@link #start()} to start it)
+     */
+    public static WalletAppKitService createTemporary(BitcoinNetwork network, ScriptType scriptType, String walletBaseName) {
+        Context.propagate(new Context());
+        String filePrefix = walletBaseName + "-" + network;
+        File dataDirectory = null;
+        try {
+            dataDirectory = Files.createTempDirectory(walletBaseName).toFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        log.info("Returning WalletAppKit bean, wallet directory: {}, prefix: {}", dataDirectory.getAbsolutePath(), filePrefix);
+        WalletAppKit walletAppKit = new WalletAppKit(network, scriptType, KeyChainGroupStructure.BIP43, dataDirectory, filePrefix);
+        return new WalletAppKitService(walletAppKit);
+    }
+
+    /**
+     * Construct from an (un-started) {@link WalletAppKit} instance.
      * @param walletAppKit instance
      */
     @Inject
@@ -94,6 +158,7 @@ public class WalletAppKitService implements BitcoinJsonRpc, Closeable {
         kit.setBlockingStartup(false);  // `false` means startup is complete when network activity begins
         kit.startAsync();
         kit.awaitRunning();
+        signingService = new WalletSigningService(kit.wallet());
     }
 
     public Network network() {
@@ -245,21 +310,156 @@ public class WalletAppKitService implements BitcoinJsonRpc, Closeable {
                 address));
     }
 
-    @Override
-    public CompletableFuture<String> getnewaddress() {
-        List<DeterministicKey> keys = kit.wallet().getActiveKeyChain().getKeys(KeyChain.KeyPurpose.RECEIVE_FUNDS, 1);
-        Address address = keys.get(0).toAddress(ScriptType.P2PKH, network);
-        return CompletableFuture.completedFuture(address.toString());
+    record outpoint(Sha256Hash txId, int vout) {
+        public outpoint(String idString, int vout) {
+            this(Sha256Hash.wrap(idString), vout);
+        }
+        public outpoint(Map<String, Object> json) {
+            this((String) json.get("txid"), ((Number) json.get("vout")).intValue());
+        }
+
+    }
+    record output(Address address, Coin amount) {
+        public output(String addString, String amountString) {
+            this(parser.parseAddressAnyNetwork(addString),  Coin.parseCoin(amountString));
+        }
+        Script script() {
+            return ScriptBuilder.createP2PKHOutputScript(this.address().getHash());
+        }
     }
 
     @Override
-    public CompletableFuture<String> getbalance() {
-        return CompletableFuture.completedFuture(kit.wallet().getBalance().toPlainString());
+    public CompletableFuture<String> createrawtransaction(List<Map<String, Object>> inputs, List<Map<String, String>> outputs) {
+        try {
+            List<? extends TransactionInputData> ins = inputs.stream()
+                    .map(outpoint::new)
+                    .flatMap(op -> signingService.findUnspentOutput(op.txId, op.vout).stream())
+                    .map(TransactionInputData::fromTxOut)
+                    .toList();
+            List<? extends TransactionOutputData> outs = outputs.stream()
+                    .flatMap(map -> map.entrySet().stream())
+                    .map(entry -> new output(entry.getKey(), entry.getValue()))
+                    .map(o -> new TransactionOutputDataScript(o.amount(), o.script()))
+                    .toList();
+            // TODO: Add a change output?
+            SigningRequest sr = new DefaultSigningRequest(network, (List<TransactionInputData>) ins, (List<TransactionOutputData>) outs);
+            Transaction rawTx = sr.toUnsignedTransaction();
+            return CompletableFuture.completedFuture(rawTx.toHexString());
+        } catch (Throwable t) {
+            return CompletableFuture.failedFuture(t);
+        }
     }
 
     @Override
-    public CompletableFuture<Sha256Hash> sendtoaddress(String address, Double amount) {
-        return exception(new UnsupportedOperationException("Unimplemented RPC method"));
+    public CompletableFuture<Address> getnewaddress() {
+        DeterministicKey key = kit.wallet().getActiveKeyChain().getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
+        Address address = key.toAddress(ScriptType.P2PKH, network);
+        log.warn("address {} key path: {}", address, key.getPathAsString());
+        return CompletableFuture.completedFuture(address);
+    }
+
+    @Override
+    public CompletableFuture<Coin> getbalance() {
+        return CompletableFuture.completedFuture(kit.wallet().getBalance());
+    }
+
+    @Override
+    public CompletableFuture<List<UnspentOutput>> listunspent(Integer minConf, Integer maxConf, List<String> addresses, Boolean includeUnsafe) {
+        List<Address> addressList = addresses != null
+                ? addresses.stream().map(parser::parseAddressAnyNetwork).toList()
+                : List.of();
+        List<TransactionOutput> outs = signingService.findUnspentOutputs(
+                                            minConf != null ? minConf : DEFAULT_MIN_CONF,
+                                            maxConf != null ? maxConf : DEFAULT_MAX_CONF,
+                                            addressList);
+        List<UnspentOutput> unspents = outs.stream()
+                .map(out -> new UnspentOutput(
+                        out.getParentTransactionHash(),
+                        out.getIndex(),
+                        null, // Address (get from script?)
+                        "", // label
+                        hexFormat.formatHex(out.getScriptPubKey().getProgram()), // scriptPubKey
+                        out.getValue(),     // amount
+                        out.getParentTransactionDepthInBlocks(),  // confirmations
+                        null,   // redeemScript
+                        null,   // witnessScript
+                        true,   // spendable
+                        true,   // solvable
+                        "description",  // description
+                        true)   // safe
+                )
+                .toList();
+        return CompletableFuture.completedFuture(unspents);
+    }
+
+    /**
+     * Send coins to an address
+     * @param toAddressString Address to send coins to
+     * @param amountDouble Amount to send
+     * @return future that completes with a transaction hash/id when the tx is successfully relayed
+     */
+    @Override
+    public CompletableFuture<Sha256Hash> sendtoaddress(String toAddressString, Double amountDouble) {
+        log.info("sendtoaddress {}, {}", toAddressString, amountDouble);
+        Address toAddress = parser.parseAddress(toAddressString, network);
+        Coin amount = Coin.ofBtc(BigDecimal.valueOf(amountDouble));
+        Transaction signedTx;
+        try {
+            signedTx = signingService.signSendToAddress(toAddress, amount).join();
+        } catch (IOException | InsufficientMoneyException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+        return sendTransaction(signedTx)
+                .thenCompose(tb1 -> tb1.awaitRelayed()
+                        .thenApply(tb2 -> tb2.transaction()
+                                .getTxId()
+                        )
+                );
+    }
+
+    @Override
+    public CompletableFuture<Sha256Hash> sendrawtransaction(String hex) {
+        ByteBuffer raw = ByteBuffer.wrap(hexFormat.parseHex(hex));
+        Transaction signedTx;
+        try {
+            signedTx = new Transaction(NetworkParameters.of(network), raw);
+        } catch (ProtocolException e) {
+            return CompletableFuture.failedFuture(new RuntimeException("Invalid raw (hex) transaction", e));
+        }
+        return sendTransaction(signedTx)
+                .thenCompose(tb1 -> tb1.awaitRelayed()
+                        .thenApply(tb2 -> tb2.transaction()
+                                .getTxId()
+                        )
+                );
+    }
+
+    /**
+     * @param hex hex-encoded unsigned raw transaction
+     * @return signed raw transaction
+     */
+    @Override
+    public CompletableFuture<SignedRawTransaction> signrawtransactionwithwallet(String hex) {
+        ByteBuffer raw = ByteBuffer.wrap(hexFormat.parseHex(hex));
+        Transaction unsignedTx;
+        try {
+            unsignedTx = new Transaction(NetworkParameters.of(network), raw);
+        } catch (ProtocolException e) {
+            return CompletableFuture.failedFuture(new RuntimeException("Invalid raw (hex) transaction", e));
+        }
+        SigningRequest signingRequest = SigningRequest.ofTransaction(network, unsignedTx);
+
+        return signingService.signTransaction(signingRequest)
+                .thenApply(SignedRawTransaction::of);
+    }
+
+    private CompletableFuture<TransactionBroadcast> sendTransaction(Transaction tx) {
+        try {
+            kit.wallet().commitTx(tx);
+            return kit.peerGroup().broadcastTransaction(tx).awaitSent();
+        } catch (VerificationException ve) {
+            return CompletableFuture.failedFuture(ve);
+        }
     }
 
     private CompletableFuture<byte[]> getBlockBytes(Sha256Hash blockHash) {

--- a/cj-btc-services/src/main/java/org/consensusj/bitcoin/services/WalletSigningService.java
+++ b/cj-btc-services/src/main/java/org/consensusj/bitcoin/services/WalletSigningService.java
@@ -1,0 +1,113 @@
+package org.consensusj.bitcoin.services;
+
+import org.bitcoinj.base.Address;
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.wallet.Wallet;
+import org.consensusj.bitcoin.json.rpc.BitcoinJsonRpc;
+import org.consensusj.bitcoinj.service.SignTransactionService;
+import org.consensusj.bitcoinj.signing.DefaultSigningRequest;
+import org.consensusj.bitcoinj.signing.FeeCalculator;
+import org.consensusj.bitcoinj.signing.HDKeychainSigner;
+import org.consensusj.bitcoinj.signing.SigningRequest;
+import org.consensusj.bitcoinj.signing.SigningUtils;
+import org.consensusj.bitcoinj.signing.TestnetFeeCalculator;
+import org.consensusj.bitcoinj.signing.TransactionInputData;
+import org.consensusj.bitcoinj.signing.TransactionOutputAddress;
+import org.consensusj.bitcoinj.signing.TransactionOutputData;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Transaction completion and signing service that uses a bitcoinj {@link Wallet}. This
+ * service can find available UTXOs, build and sign transactions.
+ */
+public class WalletSigningService implements SignTransactionService {
+    private final Wallet wallet;
+    private final HDKeychainSigner signer;
+    private final FeeCalculator feeCalculator = new TestnetFeeCalculator();
+
+    public WalletSigningService(Wallet wallet) {
+        this.wallet = wallet;
+        signer = new HDKeychainSigner(wallet.getActiveKeyChain());
+    }
+
+    @Override
+    public CompletableFuture<Transaction> signTransaction(SigningRequest request) {
+        return signer.signTransaction(request);
+    }
+
+    /**
+     * Create and sign a transaction to send coins to the specified address. Implements the transaction-building
+     * and signing portion of `sendtoaddress` RPC.
+     * @param toAddress destination address
+     * @param amount amount to send
+     * @return a future signed transaction
+     */
+    @Override
+    public CompletableFuture<Transaction> signSendToAddress(Address toAddress, Coin amount) throws IOException, InsufficientMoneyException {
+        List<TransactionInputData> utxos = getInputs();
+        TransactionOutputData outputData = new TransactionOutputAddress(amount, toAddress);
+        SigningRequest bitcoinSendReq = createBitcoinSigningRequest(wallet.network(), utxos, List.of(outputData), wallet.currentChangeAddress());
+        return signer.signTransaction(bitcoinSendReq);
+    }
+    
+    @Override
+    public SigningRequest createBitcoinSigningRequest(Network network, List<? super TransactionInputData> inputUtxos, List<TransactionOutputData> outputs, Address changeAddress) throws InsufficientMoneyException {
+        SigningRequest request = new DefaultSigningRequest(network, (List<TransactionInputData>) inputUtxos, outputs);
+        // TODO: see Wallet.calculateFee
+        return SigningUtils.addChange(request, changeAddress, feeCalculator);
+    }
+
+    List<TransactionInputData> getInputs() {
+        List<TransactionOutput> spendCandidates = findUnspentOutputs(1, BitcoinJsonRpc.DEFAULT_MAX_CONF, List.of());
+        List<? extends TransactionInputData> utxos  = spendCandidates.stream()
+                .map(TransactionInputData::fromTxOut)
+                .toList();
+        return (List<TransactionInputData>) utxos;
+    }
+
+    /**
+     * @param txId txid
+     * @param vout output index
+     * @return  list of matching transaction outputs (bitcoinj objects)
+     */
+    Optional<TransactionOutput> findUnspentOutput(Sha256Hash txId, int vout) {
+        return wallet.calculateAllSpendCandidates().stream()
+                .filter(out -> out.getParentTransactionDepthInBlocks() >= 1 &&
+                        out.getParentTransactionHash().equals(txId) &&
+                        out.getIndex() == vout)
+                .findFirst();
+    }
+
+    /**
+     * @param minConf minimum confirmations
+     * @param maxConf maximum confirmations
+     * @param addresses List of wallet addresses these outputs should belong to (empty list is allowed matches all addresses)
+     * @return  list of matching transaction outputs (bitcoinj objects)
+     */
+    List<TransactionOutput> findUnspentOutputs(int minConf, int maxConf, Collection<Address> addresses) {
+        return wallet.calculateAllSpendCandidates().stream()
+                .filter(out -> out.getParentTransactionDepthInBlocks() >= minConf &&
+                                out.getParentTransactionDepthInBlocks() <= maxConf &&
+                                matchesAddresses(out, addresses))
+                .toList();
+    }
+
+    // empty collection is wildcard
+    private boolean matchesAddresses(TransactionOutput out, Collection<Address> addresses) {
+        return addresses.size() == 0 || addresses.stream().anyMatch(a -> matchesAddress(out, a));
+    }
+
+    private boolean matchesAddress(TransactionOutput out, Address address) {
+        return out.getScriptPubKey().getToAddress(wallet.getParams()).equals(address);
+    }
+}

--- a/cj-btc-services/src/test/groovy/org/consensusj/bitcoin/services/WalletAppKitServiceSpec.groovy
+++ b/cj-btc-services/src/test/groovy/org/consensusj/bitcoin/services/WalletAppKitServiceSpec.groovy
@@ -1,0 +1,25 @@
+package org.consensusj.bitcoin.services
+
+import org.bitcoinj.base.BitcoinNetwork
+import org.bitcoinj.base.ScriptType
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ *
+ */
+class WalletAppKitServiceSpec extends Specification {
+    @Shared
+    WalletAppKitService appKitService;
+
+    def setupSpec() {
+        appKitService = WalletAppKitService.createTemporary(BitcoinNetwork.REGTEST, ScriptType.P2PKH, "cj-btc-services-unittest")
+        appKitService.start()
+    }
+
+    def 'loaded correctly'() {
+        expect:
+        appKitService != null
+        appKitService.network() == BitcoinNetwork.REGTEST
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,13 +12,14 @@ if (!JavaVersion.current().isJava11Compatible()) {
     include 'cj-bitcoinj-util'                  // BlockUtil (and future stuff depending on only bitcoinj)
     include 'cj-bitcoinj-dsl-gvy'               // Groovy DSL for bitcoinj
 
-// JDK 9
+// JDK 11
     include 'consensusj-analytics'              // Reactive analytics libraries
     include 'consensusj-currency'               // JavaMoney Currency Provider(s)
     include 'consensusj-decentralized-id'       // W3C Decentralized ID library (in-process)
     include 'consensusj-exchange'               // JavaMoney Exchange Providers
     include 'consensusj-jsonrpc'                // JSON-RPC Java client
     include 'consensusj-jsonrpc-gvy'            // JSON-RPC Groovy client
+    include 'consensusj-jsonrpc-javanet'        // JSON-RPC client using java.net.http (incubating)
     include 'consensusj-rx-jsonrpc'             // RxJava 3 adapter for JSON-RPC
     include 'consensusj-rx-zeromq'              // RxJava 3 adapter for ZeroMQ (uses JeroMQ)
     include 'cj-btc-rx'                         // bitcoinj-based RxJava interfaces
@@ -27,12 +28,8 @@ if (!JavaVersion.current().isJava11Compatible()) {
     include 'cj-btc-json'                       // JSON <-> Java Object mapping
     include 'cj-btc-jsonrpc'                    // Bitcoin JSON-RPC client using bitcoinj-based types
     include 'cj-btc-jsonrpc-gvy'                // Bitcoin JSON-RPC client with Groovy dynamic method support
-    include 'cj-btc-jsonrpc-integ-test'         // RPC-based integration tests of bitcoind
     include 'cj-eth-jsonrpc'                    // Ethereum JSON-RPC client (experimental)
     include 'cj-nmc-jsonrpc'                    // Namecoin JSON-RPC client (experimental)
-
-// JDK 11
-    include 'consensusj-jsonrpc-javanet'        // JSON-RPC client using java.net.http (incubating)
 
 if (JavaVersion.current().compareTo(JavaVersion.VERSION_17) >= 0) {
     System.err.println "Including JDK 17 modules because Java ${JavaVersion.current()} is JDK 17+"
@@ -40,6 +37,7 @@ if (JavaVersion.current().compareTo(JavaVersion.VERSION_17) >= 0) {
     include 'cj-bitcoinj-spock'                 // Spock tests/demos of basic bitcoinj capabilities
     include 'cj-bitcoinj-dsl-js'                // JavaScript DSL for bitcoinj via Nashorn
     include 'cj-btc-daemon'                     // Prototype Micronaut version of Bitcoin daemon
+    include 'cj-btc-jsonrpc-integ-test'         // RPC-based integration tests of/using bitcoind
     include 'cj-btc-services'                   // bitcoinj-based service objects
     include 'consensusj-jsonrpc-cli'            // JSON-RPC CLI library and tool
     include 'cj-btc-cli'                        // Bitcoin JSON-RPC CLI


### PR DESCRIPTION
 Add proof-of-concept implementations of:
 
* createrawtransaction
* sendrawtransaction
* listunspent
* sendtoaddress
* signrawtransactionwithwallet

Related code-refactoring and cleanup. Also make bitcoinj peers a little less verbose in the logging configuration.