### PR TITLE
Refactor transaction signing for signtransactionwithwallet

### DIFF
--- a/cj-bitcoinj-util/build.gradle
+++ b/cj-bitcoinj-util/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 tasks.withType(JavaCompile) {
-    options.release = 8
+    options.release = 9
 }
 
 ext.moduleName = 'org.consensusj.bitcoinj.util'

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
@@ -6,6 +6,10 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +23,7 @@ public class DefaultSigningRequest implements SigningRequest {
     private final List<TransactionOutputData> outputs;
 
 
+    @Deprecated
     public DefaultSigningRequest(String networkId, List<TransactionInputData> inputs, List<TransactionOutputData> outputs) {
         this(BitcoinNetwork.fromIdString(networkId).orElseThrow(IllegalArgumentException::new), inputs, outputs);
     }
@@ -29,10 +34,12 @@ public class DefaultSigningRequest implements SigningRequest {
         this.outputs = Collections.unmodifiableList(outputs);
     }
 
+    @Deprecated
     public DefaultSigningRequest(Network network, TransactionInputData input) {
         this(network, Collections.singletonList(input), Collections.emptyList());
     }
 
+    @Deprecated
     public DefaultSigningRequest(Network network) {
         this(network, Collections.emptyList(), Collections.emptyList());
     }
@@ -52,11 +59,18 @@ public class DefaultSigningRequest implements SigningRequest {
         this(netParams.network(), Collections.emptyList(), Collections.emptyList());
     }
 
+    @Deprecated
     public DefaultSigningRequest(String networkId) {
         this(BitcoinNetwork.fromIdString(networkId).orElseThrow(IllegalArgumentException::new), Collections.emptyList(), Collections.emptyList());
     }
 
     @Override
+    public Network network() {
+        return network;
+    }
+
+    @Override
+    @Deprecated
     public String networkId() {
         return network.id();
     }
@@ -80,9 +94,9 @@ public class DefaultSigningRequest implements SigningRequest {
         NetworkParameters params = NetworkParameters.of(network);
         Transaction utx = new Transaction(params);
         this.inputs().forEach(in ->
-                utx.addInput(new TransactionInput(params,
-                        utx,
-                        in.script().getProgram())));
+                utx.addInput(in.toOutPoint(network).getHash(),
+                        in.toOutPoint(network).getIndex(),
+                        ScriptBuilder.createEmpty()));
         this.outputs().forEach(out ->
                 utx.addOutput(new TransactionOutput(params,
                         utx,

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
+
 /**
  * A "signing wallet"  that uses a {@link DeterministicKeyChain} to
  * sign {@link SigningRequest}s.
@@ -73,8 +75,25 @@ public class HDKeychainSigner implements BaseTransactionSigner {
      * @return Signing key, if available, {@link Optional#empty()} otherwise.
      */
     public Optional<ECKey> keyForInput(TransactionInputData input) {
+
         return Optional.ofNullable(
                 keyChain.findKeyFromPubHash(input.script().getPubKeyHash())
         );
+    }
+
+    /**
+     * Return the signing key for an input, if available
+     * @param pubKeyHash pubKeyHash
+     * @return Signing key, if available, {@link Optional#empty()} otherwise.
+     */
+    public Optional<ECKey> keyForHash(byte[] pubKeyHash) {
+
+        return Optional.ofNullable(
+                keyChain.findKeyFromPubHash(pubKeyHash)
+        );
+    }
+
+    public Optional<ECKey> pubKeyFromPubKeyHash(byte[] pubKeyHash) {
+        return keyForHash(pubKeyHash).map(ECKey::fromPublicOnly);
     }
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/RawTransactionSigningRequest.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/RawTransactionSigningRequest.java
@@ -1,0 +1,81 @@
+package org.consensusj.bitcoinj.signing;
+
+import org.bitcoinj.base.Network;
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.script.Script;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This represents the data in {@code signrawtransactionwithwallet}. Specifically
+ * inputs with UTXO hash and index and an empty scriptSig.
+ */
+public class RawTransactionSigningRequest {
+    private final Network network;
+    private final List<RawInput> inputs;
+    private final List<TransactionOutputData> outputs;
+
+
+    public static RawTransactionSigningRequest of(Network network, List<RawInput> inputs, List<TransactionOutputData> outputs) {
+        return new RawTransactionSigningRequest(network, inputs, outputs);
+    }
+
+    public static RawTransactionSigningRequest ofTransaction(Network network, Transaction transaction) {
+        List<RawInput> inputs = transaction.getInputs().stream()
+                .map(i -> new RawInput(i.getOutpoint().getHash(), (int) i.getOutpoint().getIndex(), i.getScriptSig()))
+                .collect(Collectors.toList());
+        List<TransactionOutputData> outputs = transaction.getOutputs().stream()
+                .map(TransactionOutputData::fromTxOutput)
+                .collect(Collectors.toList());
+        return RawTransactionSigningRequest.of(network, inputs, outputs);
+    }
+
+    public RawTransactionSigningRequest(Network network, List<RawInput> inputs, List<TransactionOutputData> outputs) {
+        this.network = network;
+        this.inputs = inputs;
+        this.outputs = outputs;
+    }
+
+    public List<RawInput> inputs() {
+        return inputs;
+    }
+
+    public List<TransactionOutputData> outputs() {
+        return outputs;
+    }
+
+    public static class RawInput {
+        private final Sha256Hash txId;
+        private final int index;
+        private final Script scriptSig;
+
+        /**
+         * @param txId id
+         * @param index index
+         * @param scriptSig typically is empty script (at least in {@code signrawtransactionwithwallet} case
+         */
+        public RawInput(Sha256Hash txId, int index, Script scriptSig) {
+            this.txId = txId;
+            this.index = index;
+            this.scriptSig = scriptSig;
+        }
+
+        public Sha256Hash txId() {
+            return txId;
+        }
+
+        public int index() {
+            return index;
+        }
+
+        public Script scriptSig() {
+            return scriptSig;
+        }
+
+        public Utxo.Basic toUtxo() {
+            return Utxo.of(txId, index);
+        }
+    }
+}

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
@@ -1,30 +1,69 @@
 package org.consensusj.bitcoinj.signing;
 
+import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
+import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
 
 /**
- *
+ * I am a class with existential issues. Am I a TransactionInputSpec? or am I TransactionInputData?
  */
 public interface TransactionInputData {
     Coin amount();
+
+    /**
+     * prevOut ScriptPubKey
+     */
+
     Script script();
 
     /**
      * This probably shouldn't be here but is needed for proper operation with bitcoinj
-     * @return A Transaction "outpoint" pointing to the output corresponding to this input.
+     * @return A Transaction "outpoint" pointing to the utxo this input will spend.
      */
     TransactionOutPoint toOutPoint(Network network);
 
+    Utxo toUtxo();
+
     /**
-     * Create a transaction input from an unspent transaction output.
+     * Create from a UTXO that paid to an address the intended signer can redeem
+     */
+    static TransactionInputData of(Utxo.Signable utxo, Address address) {
+        return new TransactionInputDataUtxo(utxo.txId(), utxo.index(), utxo.amount(), ScriptBuilder.createOutputScript(address));
+    }
+
+    /**
+     * Create from a UTXO that paid to a script the intended signer can redeem
+     * @param utxo Complete UTXO info
+     * @return input ready for signing
+     */
+    static TransactionInputData of(Utxo.Complete utxo) {
+        return new TransactionInputDataUtxo(utxo.txId(), utxo.index(), utxo.amount(), utxo.scriptPubKey());
+    }
+
+    /**
+     * Create an unsigned transaction input from an unspent transaction output that the signer can redeem
      * @param out An unspent transaction output
      * @return transaction input data
      */
-    static TransactionInputDataImpl fromTxOut(TransactionOutput out) {
-        return new TransactionInputDataImpl(out.getParentTransactionHash(), out.getIndex(), out.getValue(), out.getScriptPubKey());
+    static TransactionInputData fromTxOut(TransactionOutput out) {
+        return new TransactionInputDataUtxo(out.getParentTransactionHash(), out.getIndex(), out.getValue(), out.getScriptPubKey());
+    }
+
+    /**
+     * Create an unsigned transaction input from an bitcoinj (unsigned) TransactionInput.
+     * @param input A transaction input (typically/currently unsigned)
+     * @return transaction input data
+     */
+    static TransactionInputData fromTxInput(TransactionInput input) {
+        return new TransactionInputDataUtxo(
+                input.getOutpoint().getHash(),
+                (int) input.getOutpoint().getIndex(),
+                input.getValue(),
+                input.getScriptSig());
     }
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputData.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputData.java
@@ -1,5 +1,6 @@
 package org.consensusj.bitcoinj.signing;
 
+import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.core.TransactionOutput;
@@ -12,6 +13,16 @@ import org.bitcoinj.script.Script;
 public interface TransactionOutputData {
     Coin amount();
     Script script();
+
+    static TransactionOutputData of(Address address, Coin amount) {
+        return new TransactionOutputAddress(amount, address);
+    }
+
+    static TransactionOutputData fromTxOutput(TransactionOutput out) {
+        return new TransactionOutputDataScript(
+                out.getValue(),
+                out.getScriptPubKey());
+    }
 
     default TransactionOutput toMutableOutput(Network network) {
         return new TransactionOutput(BitcoinNetworkParams.of(network), null, amount(), script().getProgram());

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionVerification.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionVerification.java
@@ -9,7 +9,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptException;
 
 /**
- *
+ * Utility for transaction validation
  */
 public class TransactionVerification {
     /**

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/Utxo.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/Utxo.java
@@ -1,0 +1,133 @@
+package org.consensusj.bitcoinj.signing;
+
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.script.Script;
+
+import java.util.Objects;
+
+/**
+ *  UTXO info for transaction signing. Immutable and all fields non-nullable.
+ *  <p>Non-segwit can be signed without amount, but we're focusing on modern Bitcoin, so
+ *  we're going to simplify things by making {@link Utxo.Signable} mandatory in many methods.
+ */
+public interface Utxo {
+    Sha256Hash txId();
+    int index();
+
+    static Basic of(Sha256Hash txId, int index) {
+        return new Basic(txId, index);
+    }
+
+    static Signable of(Sha256Hash txId, int index, Coin amount) {
+        return new Signable(txId, index, amount);
+    }
+
+    static Complete of(Sha256Hash txId, int index, Coin amount, Script scriptPubKey) {
+        return new Complete(txId, index, amount, scriptPubKey);
+    }
+
+    static Utxo of(TransactionOutPoint outPoint) {
+        if (outPoint.getConnectedOutput() == null || outPoint.getConnectedOutput().getValue() == null) {
+            throw new IllegalArgumentException("outpoint is not complete enough: no value ");
+        }
+        if (outPoint.getConnectedOutput().getScriptPubKey() == null) {
+            return new Signable(outPoint.getHash(), (int) outPoint.getIndex(), outPoint.getConnectedOutput().getValue());
+        } else {
+            return new Signable(outPoint.getHash(), (int) outPoint.getIndex(), outPoint.getConnectedOutput().getValue());
+        }
+    }
+
+    /**
+     * Bare minimum UTXO info: txId and index
+     */
+    class Basic implements Utxo {
+        private final Sha256Hash txId;
+        private final int index;
+
+        public Basic(Sha256Hash txId, int index) {
+            this.txId = Objects.requireNonNull(txId);
+            this.index = index;
+        }
+
+        @Override
+        public Sha256Hash txId() {
+            return txId;
+        }
+
+        @Override
+        public int index() {
+            return index;
+        }
+
+        Signable addAmount(Coin amount) {
+            return Utxo.of(txId, index, amount);
+        }
+    }
+
+    /**
+     * UTXO with "amount" which is necessary for signing a segwit transaction.
+     */
+    class Signable implements Utxo {
+        private final Sha256Hash txId;
+        private final int index;
+        private final Coin amount;
+
+        public Signable(Sha256Hash txId, int index, Coin amount) {
+            this.txId = Objects.requireNonNull(txId);
+            this.index = index;
+            this.amount = Objects.requireNonNull(amount);
+        }
+
+        @Override
+        public Sha256Hash txId() {
+            return txId;
+        }
+
+        @Override
+        public int index() {
+            return index;
+        }
+
+        public Coin amount() {
+            return amount;
+        }
+    }
+
+    /**
+     * UTXO with {@code amount} and {@code scriptPubKey}. Everything needed to build a transaction input with
+     * {@code scriptSig} to spend this output.
+     */
+    class Complete implements Utxo {
+        private final Sha256Hash txId;
+        private final int index;
+        private final Coin amount;
+        private final Script scriptPubKey;
+
+        public Complete(Sha256Hash txId, int index, Coin amount, Script scriptPubKey) {
+            this.txId = Objects.requireNonNull(txId);
+            this.index = index;
+            this.amount = Objects.requireNonNull(amount);
+            this.scriptPubKey = Objects.requireNonNull(scriptPubKey);
+        }
+
+        @Override
+        public Sha256Hash txId() {
+            return txId;
+        }
+
+        @Override
+        public int index() {
+            return index;
+        }
+
+        public Coin amount() {
+            return amount;
+        }
+
+        public Script scriptPubKey() {
+            return scriptPubKey;
+        }
+    }
+}

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/DeterministicKeychainBaseSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/DeterministicKeychainBaseSpec.groovy
@@ -36,18 +36,10 @@ abstract class DeterministicKeychainBaseSpec extends Specification {
         Network network = BitcoinNetwork.TESTNET
         Transaction parentTx = firstChangeTransaction()
         TransactionOutput utxo = parentTx.getOutput(1)
-        Coin utxoAmount = utxo.value
-
-        Coin txAmount = 0.01.btc
-        Coin changeAmount = 0.20990147.btc
-
-        TransactionInputDataImpl input = new TransactionInputDataImpl(parentTx.txId.bytes, utxo.index, utxoAmount.toSat(), utxo.scriptBytes)
-        List<TransactionInputDataImpl> inputs = List.of(input)
-        List<TransactionOutputData> outputs = List.of(
-                new TransactionOutputAddress(txAmount.value, toAddress),
-                new TransactionOutputAddress(changeAmount.value, changeAddress)
-        )
-        return new DefaultSigningRequest(network, inputs, outputs)
+        
+        return SigningRequest.of(network,
+                [TransactionInputData.fromTxOut(utxo)],
+                [(toAddress): 0.01.btc, (changeAddress): 0.20990147.btc])
     }
 
 

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/ECKeySignerSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/ECKeySignerSpec.groovy
@@ -15,8 +15,7 @@ class ECKeySignerSpec extends DeterministicKeychainBaseSpec {
     // WIF for private key used in Bitcoins the Hard Way
     static final ECKey fromKey = ECKey.fromWIF("5HusYj2b2x4nroApgfvaSfKYZhRbKFH41bVyPooymbC6KfgSXdD", true)
     static final Sha256Hash input_txid = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48")
-    static final int input_vout = 0;
-    static final Coin input_amount = Coin.SATOSHI;
+    static final Utxo utxo = Utxo.of(input_txid, 0, Coin.SATOSHI);
 
     def "Can sign a simple Tx"(BitcoinNetwork network, ScriptType scriptType) {
         given:
@@ -28,10 +27,10 @@ class ECKeySignerSpec extends DeterministicKeychainBaseSpec {
         ECKeySigner signer = new ECKeySigner(fromKey)
 
         and: "We sign a transaction"
-        SigningRequest signingRequest = new DefaultSigningRequest(network)
-                .addInput(fromAddress, input_amount, input_txid, input_vout)
-                .addOutput(toAddress, 0.01.btc)
-                .addOutput(changeAddress, 0.20990147.btc)
+        SigningRequest signingRequest = SigningRequest.of(network,
+                [TransactionInputData.of(utxo, fromAddress)],
+                [(toAddress): 0.01.btc, (changeAddress): 0.20990147.btc])
+
         Transaction signedTx = signer.signTransaction(signingRequest).join()
 
         then:

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/RpcServerModule.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/RpcServerModule.java
@@ -9,6 +9,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.Transaction;
+import org.bitcoinj.script.Script;
 
 /**
  *
@@ -26,7 +27,8 @@ public class RpcServerModule extends SimpleModule {
                 .addSerializer(ECKey.class, new ECKeySerializer())
                 .addSerializer(Peer.class, new PeerSerializer())
                 .addSerializer(Sha256Hash.class, new Sha256HashSerializer())
-                .addSerializer(Transaction.class, new TransactionSerializer());
+                .addSerializer(Transaction.class, new TransactionSerializer())
+                .addSerializer(Script.class, new ScriptSerializer());
     }
 
     @Deprecated

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/ScriptSerializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/ScriptSerializer.java
@@ -1,0 +1,20 @@
+package org.consensusj.bitcoin.json.conversion;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.bitcoinj.base.Address;
+import org.bitcoinj.script.Script;
+
+import java.io.IOException;
+
+/**
+ *
+ */
+public class ScriptSerializer extends JsonSerializer<Script>  {
+    @Override
+    public void serialize(Script script, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
+        gen.writeString(HexUtil.bytesToHexString(script.getProgram()));
+    }
+}

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
@@ -2,6 +2,8 @@ package org.consensusj.bitcoin.json.pojo;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.script.Script;
+import org.consensusj.bitcoin.json.conversion.HexUtil;
 
 /**
  *
@@ -9,7 +11,7 @@ import org.bitcoinj.base.Sha256Hash;
 public class PrevTxOutInfo implements UtxoInfo {
     private final Sha256Hash txId;
     private final int vout;
-    private final String scriptPubKey;
+    private final Script scriptPubKey;
     private final String redeemScript;
     private final String witnessScript;
     private final Coin amount;
@@ -17,7 +19,7 @@ public class PrevTxOutInfo implements UtxoInfo {
     public PrevTxOutInfo(Sha256Hash txId, int vout, String scriptPubKey, String redeemScript, String witnessScript, Coin amount) {
         this.txId = txId;
         this.vout = vout;
-        this.scriptPubKey = scriptPubKey;
+        this.scriptPubKey = new Script(HexUtil.hexStringToByteArray(scriptPubKey));
         this.redeemScript = redeemScript;
         this.witnessScript = witnessScript;
         this.amount = amount;
@@ -34,7 +36,7 @@ public class PrevTxOutInfo implements UtxoInfo {
     }
 
     @Override
-    public String getScriptPubKey() {
+    public Script getScriptPubKey() {
         return scriptPubKey;
     }
 

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.script.Script;
+import org.consensusj.bitcoin.json.conversion.HexUtil;
 
 /**
  * Data class for UnspentOutput as returned by listUnspent RPC
@@ -15,7 +17,7 @@ public class UnspentOutput implements UtxoInfo {
     private final int         vout;
     private final Address     address;
     private final String      label;
-    private final String      scriptPubKey;
+    private final Script      scriptPubKey;
     private final Coin        amount;
     private final int         confirmations;
 
@@ -45,7 +47,7 @@ public class UnspentOutput implements UtxoInfo {
         this.vout = vout;
         this.address = address;
         this.label = label;
-        this.scriptPubKey = scriptPubKey;
+        this.scriptPubKey = new Script(HexUtil.hexStringToByteArray(scriptPubKey));
         this.amount = amount;
         this.confirmations = confirmations;
         this.redeemScript = redeemScript;
@@ -72,7 +74,7 @@ public class UnspentOutput implements UtxoInfo {
         return label;
     }
 
-    public String getScriptPubKey() {
+    public Script getScriptPubKey() {
         return scriptPubKey;
     }
 

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UtxoInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UtxoInfo.java
@@ -2,6 +2,7 @@ package org.consensusj.bitcoin.json.pojo;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.script.Script;
 
 /**
  * Interface for commonly-used UTXO information, for example the {@code prevtxs} parameter of
@@ -12,7 +13,7 @@ public interface UtxoInfo {
 
     int getVout();
 
-    String getScriptPubKey();
+    Script getScriptPubKey();
 
     String getRedeemScript();
 

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
@@ -1,0 +1,118 @@
+package org.consensusj.bitcoin.integ.services
+
+import groovy.util.logging.Slf4j
+import org.bitcoinj.base.Address
+import org.bitcoinj.base.BitcoinNetwork
+import org.bitcoinj.base.ScriptType
+import org.bitcoinj.core.NetworkParameters
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.core.TransactionOutput
+import org.bitcoinj.crypto.ECKey
+import org.bitcoinj.params.BitcoinNetworkParams
+import org.consensusj.bitcoin.json.pojo.UnspentOutput
+import org.consensusj.bitcoin.services.WalletAppKitService
+import org.consensusj.bitcoin.services.WalletSigningService
+import org.consensusj.bitcoin.test.BaseRegTestSpec
+import org.consensusj.bitcoinj.signing.RawTransactionSigningRequest
+import org.consensusj.bitcoinj.signing.SigningRequest
+import org.consensusj.bitcoinj.signing.TransactionInputData
+import org.consensusj.bitcoinj.signing.Utxo
+import spock.lang.Shared
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * RegTest Integration test of WalletSigningService using WalletAppKitService
+ */
+@Slf4j
+class WalletSigningServiceRegTestSpec extends BaseRegTestSpec {
+    /** The WalletAppKitService that provides UTXOs for testing */
+    @Shared WalletAppKitService appKitService
+    @Shared WalletSigningService signingService;
+    @Shared Address spvWalletAddress
+    @Shared UnspentOutput unspentOutput
+    
+    def setupSpec() {
+        appKitService = WalletAppKitService.createTemporary(BitcoinNetwork.REGTEST, ScriptType.P2PKH, "cj-btc-services-unittest")
+        appKitService.start()
+        signingService = appKitService.signingService   // access private member using Groovy reflection
+        assert appKitService.network() == BitcoinNetwork.REGTEST
+        spvWalletAddress = appKitService.getnewaddress().join()
+        log.info("spvWalletAddress: {}", spvWalletAddress)
+
+        var txId = requestBitcoin(spvWalletAddress, 2.btc)
+        assert txId != null
+        generateBlocks(1)
+        waitForWalletSync()
+
+        var balance = appKitService.getbalance().join()
+        assert balance >= 2.btc
+
+        var list = appKitService.listunspent(null, null, List.of(spvWalletAddress.toString()), false).join()
+        unspentOutput = list.get(0)
+    }
+
+    def "serialize, deserialize and sign a transaction - similar to sendrawtransactionwithwallet"() {
+        given: "a UTXO to spend, a toAddress, and a desired amount to send"
+        var utxo = Utxo.of(unspentOutput.txid, unspentOutput.vout, unspentOutput.amount, unspentOutput.scriptPubKey)
+        var toAddr = new ECKey().toAddress(ScriptType.P2PKH, network)
+        var sendAmount = 1.5.btc
+
+        when: "we build an unsigned tx via a SigningRequest"
+        var changeAmount = utxo.amount() - (sendAmount + 0.1.btc)
+        var signingRequest = SigningRequest.of(network,
+                [TransactionInputData.of(utxo)],
+                [(toAddr): sendAmount,
+                 (spvWalletAddress): changeAmount]  // Change
+        )
+        var uTx = signingRequest.toUnsignedTransaction()
+
+        then: "it is correctly built"
+        uTx.getOutputSum() >= 0.9.btc
+
+        when: "we serialize it"
+        byte[] serialized = uTx.bitcoinSerialize()
+        var buf = ByteBuffer.wrap(serialized).order(ByteOrder.LITTLE_ENDIAN)
+
+        then: "it is serialized properly"
+        buf.getInt() == 1                  // Version
+        buf.get()    == (byte) 1           // Input count
+        // input 1
+        // TODO: simple parsing and testing illustrating raw buffer format
+
+        // TODO: Maybe we need more an INPUT BUILDER more than a transaction builder!!
+
+
+        when: "we deserialize it"
+        var raw = ByteBuffer.wrap(serialized);
+        var dTx = new Transaction(NetworkParameters.of(network), raw)
+        var req = RawTransactionSigningRequest.ofTransaction(network, dTx)
+
+        then: "it has all the information we need to prepare it for signing"
+        req != null
+
+        when: "we complete it"
+        var in0 = req.inputs().get(0)
+        var dUtxo = signingService.findUtxo(in0.toUtxo()).get()
+        var finalInput = TransactionInputData.of(dUtxo)
+        var completeTx = SigningRequest.of(appKitService.network(), List.of(finalInput), req.outputs())
+        var sTx = signingService.signTransaction(completeTx).join()
+
+        then: "it is complete"
+        sTx != null
+   }
+
+    /**
+     * Wait for the bitcoinj wallet to sync with the Bitcoin Core blockchain
+     */
+    void waitForWalletSync() {
+        int walletHeight, serverHeight
+        while ( (walletHeight = appKitService.getblockcount().join()) < (serverHeight = client.getBlockCount()) ) {
+            // TODO: Figure out a way to do this without polling and sleeping
+            println "walletHeight < serverHeight: ${walletHeight} < ${serverHeight} -- Waiting..."
+            Thread.sleep(100)
+        }
+        println "walletHeight: ${walletHeight}, serverHeight: ${serverHeight}"
+    }
+}

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
@@ -1,10 +1,14 @@
 package org.consensusj.bitcoin.rpc
 
+import org.bitcoinj.core.Transaction
+import org.consensusj.bitcoin.json.conversion.HexUtil
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.Coin
 import spock.lang.Shared
 import spock.lang.Stepwise
+
+import java.nio.ByteBuffer
 
 /**
  * Tests of creating and sending raw transactions via RPC
@@ -48,6 +52,17 @@ class BitcoinRawTransactionSpec extends BaseRegTestSpec {
         then: "there should be a raw transaction"
         rawTransactionHex != null
         rawTransactionHex.size() > 0
+
+    }
+
+    def "Verify bitcoinj can round-trip the raw transaction"() {
+        when: "We parse the transaction"
+        var buffer = ByteBuffer.wrap(HexUtil.hexStringToByteArray(rawTransactionHex))
+        var transaction = new Transaction(client().getNetParams(), buffer)
+        var roundtrip = HexUtil.bytesToHexString(transaction.bitcoinSerialize())
+
+        then:
+        rawTransactionHex == roundtrip
     }
 
     def "Sign unsigned raw transaction"() {


### PR DESCRIPTION
* BaseTransactionSigner can lookup keys and pubKeys
* WalletSigningService can lookup UTXO scriptPubKey and amount

util:

* cj-bitcoinj-util: Require JDK 9 (use List.of(), etc)
* Distinguish between RawTransactionSigningRequest and SigningRequest (i.e. the later has all UTXO information and can be signed with keychain only)
* (Generally) construct SigningRequest with `of`, remove (most) add methods
* SigningRequest constructor that takes outputs as a Map<Address, Coin>
* Rename TransactionInputDataImpl to TransactionINputDataUtxo
* Utxo interface with Base, Signable, and Complete implementations

json:

* UtxoInfo, PrevTxOutInfo change scriptPubKey type to Script (from String)
* Add ScriptSerializer

regtests:

* WalletAppKitRegTestStepwise
* WalletSigningServiceRegTestSpec
* Many others