### PR TITLE
cj-btc-jsonrpc-integ-test/build.gradle: junit-jupiter-engine 5.9.3

### DIFF
--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.3"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.0"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.3"
 
     testImplementation "org.apache.groovy:groovy:${groovyVersion}"
     testImplementation ("org.apache.groovy:groovy-json:${groovyVersion}") {


### PR DESCRIPTION
For some reason Dependabot didn't propose this update. This plus today's Dependabot PRs will bring all 3 JUnit JARs in this `build.gradle` to version 5.9.3.