### PR TITLE
Upgrade to bitcoinj-0.17-alpha2

### DIFF
--- a/cj-bitcoinj-dsl-gvy/src/test/groovy/org/consensusj/bitcoinj/dsl/groovy/categories/StaticECKeyExtensionSpec.groovy
+++ b/cj-bitcoinj-dsl-gvy/src/test/groovy/org/consensusj/bitcoinj/dsl/groovy/categories/StaticECKeyExtensionSpec.groovy
@@ -2,7 +2,6 @@ package org.consensusj.bitcoinj.dsl.groovy.categories
 
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.AddressParser
-import org.bitcoinj.base.DefaultAddressParser
 import org.bitcoinj.base.ScriptType
 import org.bitcoinj.crypto.ECKey
 import spock.lang.Specification
@@ -13,13 +12,13 @@ import static org.bitcoinj.base.BitcoinNetwork.MAINNET
  * Test specification for ECKey static extension methods
  */
 class StaticECKeyExtensionSpec extends Specification {
-    static final private AddressParser addressParser = new DefaultAddressParser();
+    static final private AddressParser addressParser = AddressParser.getDefault(MAINNET);
     // WIF for private key used in Bitcoins the Hard Way
     static final fromKeyWIF = "5HusYj2b2x4nroApgfvaSfKYZhRbKFH41bVyPooymbC6KfgSXdD"
 
     // Expected P2PKH address for test WIF
-    static final expectedAddress = addressParser.parseAddress("1MMMMSUb1piy2ufrSguNUdFmAcvqrQF8M5", MAINNET)
-    static final expectedSegWitAddress = addressParser.parseAddress("bc1qqgde67hj65u4vcpfrhxq8mjemr05n2kklx68g4", MAINNET)
+    static final expectedAddress = addressParser.parseAddress("1MMMMSUb1piy2ufrSguNUdFmAcvqrQF8M5")
+    static final expectedSegWitAddress = addressParser.parseAddress("bc1qqgde67hj65u4vcpfrhxq8mjemr05n2kklx68g4")
 
     def "Can create key and address from private key WIF"() {
         when: "we create a private key from WIF format string in the article"

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/CreateWalletSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/CreateWalletSpec.groovy
@@ -2,7 +2,6 @@ package org.consensusj.bitcoinj.spock
 
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.ScriptType
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.wallet.Wallet
 import spock.lang.Specification
 
@@ -12,7 +11,7 @@ import spock.lang.Specification
 class CreateWalletSpec extends Specification {
     def "quick test"() {
         when:
-        def wallet = Wallet.createDeterministic(NetworkParameters.of(BitcoinNetwork.MAINNET), ScriptType.P2WPKH)
+        def wallet = Wallet.createDeterministic(BitcoinNetwork.MAINNET, ScriptType.P2WPKH)
 
         then:
         wallet != null

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/TransactionSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/TransactionSpec.groovy
@@ -1,11 +1,10 @@
 package org.consensusj.bitcoinj.spock
 
 import org.bitcoinj.base.Address
+import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.Coin
-import org.bitcoinj.base.DefaultAddressParser
 import org.bitcoinj.base.ScriptType
 import org.bitcoinj.base.Sha256Hash
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.crypto.ECKey
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.core.TransactionInput
@@ -25,24 +24,23 @@ import static org.bitcoinj.base.BitcoinNetwork.MAINNET
  * http://www.righto.com/2014/02/bitcoins-hard-way-using-raw-bitcoin.html
  */
 class TransactionSpec extends Specification {
-    static final addressParser = new DefaultAddressParser()
-    static final mainNetParams = NetworkParameters.of(MAINNET)
+    static final addressParser = AddressParser.getDefault(MAINNET)
 
     // Input Values
     static final ECKey fromKey = ECKey.fromWIF("5HusYj2b2x4nroApgfvaSfKYZhRbKFH41bVyPooymbC6KfgSXdD", false)
-    static final Address toAddr = addressParser.parseAddress("1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa", MAINNET)
+    static final Address toAddr = addressParser.parseAddress("1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa")
     static final Sha256Hash utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48")
     static final Coin txAmount = 0.00091234.btc
 
     // Values used for Verification
-    static final fromAddrVerify = addressParser.parseAddress("1MMMMSUb1piy2ufrSguNUdFmAcvqrQF8M5", MAINNET)
+    static final fromAddrVerify = addressParser.parseAddress("1MMMMSUb1piy2ufrSguNUdFmAcvqrQF8M5")
 
     def "Can create and serialize a transaction"() {
 
         when: "We create a signed transaction"
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, MAINNET)
-        Transaction tx = new Transaction(mainNetParams)
-        TransactionOutPoint outPoint = new TransactionOutPoint(mainNetParams, 0, utxo_id)
+        Transaction tx = new Transaction()
+        TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id)
         tx.addOutput(txAmount, toAddr)
         tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), fromKey);
 
@@ -50,7 +48,7 @@ class TransactionSpec extends Specification {
         var rawTx = ByteBuffer.wrap(tx.bitcoinSerialize())
 
         and: "We parse it into a new Transaction object"
-        Transaction parsedTx = new Transaction(mainNetParams, rawTx)
+        Transaction parsedTx = Transaction.read(rawTx)
 
         then: "Parsed transaction is as expected"
         // We can't do a byte-by-byte comparison because there is a random component to the signature

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/WalletSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/WalletSpec.groovy
@@ -1,10 +1,9 @@
 package org.consensusj.bitcoinj.spock
 
 import org.bitcoinj.base.Address
-import org.bitcoinj.base.DefaultAddressParser
+import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.Network
 import org.bitcoinj.base.ScriptType
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.crypto.ECKey
 import org.bitcoinj.wallet.Wallet
 import spock.lang.Shared
@@ -16,8 +15,7 @@ import static org.bitcoinj.base.BitcoinNetwork.MAINNET
  * Basic tests of wallet serialization/deserialization
  */
 class WalletSpec  extends Specification {
-    static final addressParser = new DefaultAddressParser()
-    static final Address roAddress = addressParser.parseAddress( "1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa", MAINNET);
+    static final Address roAddress = AddressParser.getDefault(MAINNET).parseAddress( "1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa");
 
     @Shared
     Network network
@@ -72,6 +70,6 @@ class WalletSpec  extends Specification {
     }
 
     Wallet newEmptyWallet() {
-        wallet = Wallet.createDeterministic(NetworkParameters.of(network), ScriptType.P2PKH)
+        wallet = Wallet.createDeterministic(network, ScriptType.P2PKH)
     }
 }

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/BaseTransactionSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/BaseTransactionSpec.groovy
@@ -1,10 +1,9 @@
 package org.consensusj.bitcoinj.spock.tx
 
 import org.bitcoinj.base.BitcoinNetwork
-import org.bitcoinj.base.DefaultAddressParser
+import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.ScriptType
 import org.bitcoinj.base.Sha256Hash
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.crypto.ECKey
 import spock.lang.Specification
 
@@ -13,11 +12,10 @@ import spock.lang.Specification
  *  Constants (and later methods) that can be used for multiple transaction tests
  */
 abstract class BaseTransactionSpec extends Specification {
-    static final mainNetParams = NetworkParameters.of(BitcoinNetwork.MAINNET)
     static final NotSoPrivatePrivateKey = new BigInteger(1, "180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19".decodeHex())
     static final utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48")
     static final utxo_amount = 0.00091234.btc
     static final fromKey = ECKey.fromPrivate(NotSoPrivatePrivateKey, false)
     static final fromAddr = fromKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.MAINNET)
-    static final toAddr = new DefaultAddressParser().parseAddress("1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa", BitcoinNetwork.MAINNET)
+    static final toAddr = AddressParser.getDefault(BitcoinNetwork.MAINNET).parseAddress("1KKKK6N21XKo48zWKuQKXdvSsCf95ibHFa")
 }

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/OpReturnSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/OpReturnSpec.groovy
@@ -8,6 +8,8 @@ import org.bitcoinj.script.ScriptOpCodes
 import org.bitcoinj.script.Script
 import spock.lang.Unroll
 
+import java.nio.ByteBuffer
+
 
 /**
  * Test/Demonstration of OP_RETURN transaction
@@ -21,8 +23,8 @@ class OpReturnSpec extends BaseTransactionSpec {
         def testData = 0..<length as byte[]
 
         when: "we build an OP_RETURN transaction"
-        Transaction tx = new Transaction(mainNetParams)
-        TransactionOutPoint outPoint = new TransactionOutPoint(mainNetParams, 0, utxo_id)
+        Transaction tx = new Transaction()
+        TransactionOutPoint outPoint = new TransactionOutPoint( 0, utxo_id)
         Script script = new ScriptBuilder()
                 .op(ScriptOpCodes.OP_RETURN)
                 .data(testData)
@@ -35,7 +37,7 @@ class OpReturnSpec extends BaseTransactionSpec {
         byte[] rawTx = tx.bitcoinSerialize()
 
         and: "We parse it into a new Transaction object"
-        Transaction parsedTx = new Transaction(mainNetParams, rawTx)
+        Transaction parsedTx = Transaction.read(ByteBuffer.wrap(rawTx))
 
         then: "we can retrieve the data"
         with (parsedTx.getOutput(0).scriptPubKey.chunks.get(0)) {

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/BaseTransactionSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/BaseTransactionSigner.java
@@ -1,6 +1,5 @@
 package org.consensusj.bitcoinj.signing;
 
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.script.ScriptException;
@@ -30,7 +29,7 @@ public interface BaseTransactionSigner extends TransactionSigner {
     @Override
     default CompletableFuture<Transaction> signTransaction(SigningRequest request) {
         // Create a new, empty (mutable) bitcoinj transaction
-        Transaction transaction = new Transaction(NetworkParameters.of(request.network()));
+        Transaction transaction = new Transaction();
 
         // For each output in the signing request, add an output to the bitcoinj transaction
         request.outputs().forEach(
@@ -74,7 +73,7 @@ public interface BaseTransactionSigner extends TransactionSigner {
      * @param exceptionSupplier exception to throw if key is not available.
      */
     default void addSignedInput(Transaction tx, TransactionInputData in, Supplier<? extends RuntimeException> exceptionSupplier) {
-        tx.addSignedInput(in.toOutPoint(tx.getParams().network()),
+        tx.addSignedInput(in.toOutPoint(),
                 in.script(),
                 in.amount(),
                 keyForInput(in).orElseThrow(exceptionSupplier),

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/DefaultSigningRequest.java
@@ -87,15 +87,13 @@ public class DefaultSigningRequest implements SigningRequest {
      * @return an unsigned bitcoinj transaction
      */
     public Transaction toUnsignedTransaction() {
-        NetworkParameters params = NetworkParameters.of(network);
-        Transaction utx = new Transaction(params);
+        Transaction utx = new Transaction();
         this.inputs().forEach(in ->
-                utx.addInput(in.toOutPoint(network).getHash(),
-                        in.toOutPoint(network).getIndex(),
+                utx.addInput(in.toOutPoint().getHash(),
+                        in.toOutPoint().getIndex(),
                         ScriptBuilder.createEmpty()));
         this.outputs().forEach(out ->
-                utx.addOutput(new TransactionOutput(params,
-                        utx,
+                utx.addOutput(new TransactionOutput(utx,
                         out.amount(),
                         out.scriptPubKey().getProgram())));
         return utx;

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/HDKeychainSigner.java
@@ -3,7 +3,6 @@ package org.consensusj.bitcoinj.signing;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
@@ -47,10 +46,9 @@ public class HDKeychainSigner implements BaseTransactionSigner {
         if (addresses.size() != unsignedTx.getInputs().size()) {
             throw new IllegalArgumentException("addresses and inputs must be 1:1 mapped");
         }
-        NetworkParameters netParams = unsignedTx.getParams();
 
         // Create a new, empty bitcoinj transaction
-        Transaction tx = new Transaction(netParams);
+        Transaction tx = new Transaction();
 
         // For each output in the signing request, add an output to the bitcoinj transaction
         // TODO: Transaction validation
@@ -62,7 +60,7 @@ public class HDKeychainSigner implements BaseTransactionSigner {
         for (int index = 0; index < unsignedTx.getInputs().size(); index++) {
             Address address = addresses.get(index);
             TransactionInput input = unsignedTx.getInputs().get(index);
-            TransactionOutPoint outPoint = input.duplicateDetached().getOutpoint();
+            TransactionOutPoint outPoint = input.getOutpoint().disconnectOutput();
             DeterministicKey fromKey = keyChain.findKeyFromPubHash(address.getHash());
             tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(address), input.getValue(), fromKey);
         }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputData.java
@@ -27,7 +27,7 @@ public interface TransactionInputData {
      * This probably shouldn't be here but is needed for proper operation with bitcoinj
      * @return A Transaction "outpoint" pointing to the utxo this input will spend.
      */
-    TransactionOutPoint toOutPoint(Network network);
+    TransactionOutPoint toOutPoint();
 
     Utxo toUtxo();
 

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputDataUtxo.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionInputDataUtxo.java
@@ -2,7 +2,6 @@ package org.consensusj.bitcoinj.signing;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
@@ -50,7 +49,7 @@ public class TransactionInputDataUtxo implements TransactionInputData, Utxo {
     }
     
     public TransactionInput toMutableInput(Network network) {
-        return createTransactionInput(toOutPoint(network), Coin.ofSat(amount), script);
+        return createTransactionInput(toOutPoint(), Coin.ofSat(amount), script);
     }
 
     @Override
@@ -59,11 +58,11 @@ public class TransactionInputDataUtxo implements TransactionInputData, Utxo {
     }
 
     @Override
-    public TransactionOutPoint toOutPoint(Network network) {
-        return new TransactionOutPoint(NetworkParameters.of(network), index, txId);
+    public TransactionOutPoint toOutPoint() {
+        return new TransactionOutPoint(index, txId);
     }
 
     private static TransactionInput createTransactionInput(TransactionOutPoint outPoint, Coin amount, Script script) {
-        return new TransactionInput(outPoint.getParams(), null, script.getProgram(), outPoint, amount);
+        return new TransactionInput( null, script.getProgram(), outPoint, amount);
     }
 }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputAddress.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputAddress.java
@@ -1,8 +1,8 @@
 package org.consensusj.bitcoinj.signing;
 
 import org.bitcoinj.base.Address;
+import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 
@@ -25,7 +25,7 @@ public class TransactionOutputAddress implements TransactionOutputData {
 
     public TransactionOutputAddress(long amount, String address) {
         this.amount = amount;
-        this.address = new DefaultAddressParser().parseAddressAnyNetwork(address);
+        this.address = AddressParser.getDefault().parseAddress(address);
     }
 
     @Override

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputData.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/TransactionOutputData.java
@@ -3,7 +3,6 @@ package org.consensusj.bitcoinj.signing;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.script.Script;
 
@@ -25,6 +24,6 @@ public interface TransactionOutputData {
     }
 
     default TransactionOutput toMutableOutput(Network network) {
-        return new TransactionOutput(NetworkParameters.of(network), null, amount(), scriptPubKey().getProgram());
+        return new TransactionOutput(null, amount(), scriptPubKey().getProgram());
     }
 }

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/DeterministicKeychainBaseSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/DeterministicKeychainBaseSpec.groovy
@@ -2,16 +2,9 @@ package org.consensusj.bitcoinj.signing
 
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.BitcoinNetwork
-import org.bitcoinj.base.Coin
-import org.bitcoinj.base.LegacyAddress
 import org.bitcoinj.base.Network
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.core.Transaction
-import org.bitcoinj.core.TransactionInput
 import org.bitcoinj.core.TransactionOutput
-import org.bitcoinj.script.Script
-import org.bitcoinj.script.ScriptBuilder
-import org.bitcoinj.script.ScriptException
 import org.bitcoinj.wallet.DeterministicSeed
 import spock.lang.Specification
 
@@ -45,6 +38,6 @@ abstract class DeterministicKeychainBaseSpec extends Specification {
 
     protected static Transaction firstChangeTransaction() {
         final byte[] change_tx_bytes = "0100000001cc652689b217db0cec03cab18a629437a0f1e308db9ee30b934b6989be50641f000000006b4830450221008f9abcda51669dc501a68d2778e2fc33f25d62d74ec791b2776733e14c39aba502201f79445d6eb4364ae83a0579ee0414abe285df034a5e42d0e15938f3f4861c91012102878641346f6ccfa4ed0a50f1786bfbd1891ff200b4c040040a804abc2c5ad69affffffff0240420f00000000001976a9145ab93563a289b74c355a9b9258b86f12bb84affb88acafe34f01000000001976a9149b1077b9d102fcc105e99a906cfd34285928b03e88ac00000000".decodeHex()
-        return new Transaction(NetworkParameters.of(BitcoinNetwork.TESTNET), ByteBuffer.wrap(change_tx_bytes))
+        return Transaction.read(ByteBuffer.wrap(change_tx_bytes))
     }
 }

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/ECKeySignerSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/ECKeySignerSpec.groovy
@@ -35,7 +35,7 @@ class ECKeySignerSpec extends DeterministicKeychainBaseSpec {
 
         then:
         signedTx != null
-        signedTx.verify()
+        Transaction.verify(network, signedTx)
 
         when: "We validate the signature on the input"
         TransactionVerification.correctlySpendsInput(signedTx, 0, fromAddress)

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/HDKeychainSignerSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/HDKeychainSignerSpec.groovy
@@ -1,10 +1,9 @@
 package org.consensusj.bitcoinj.signing
 
 import org.bitcoinj.base.Address
+import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.Coin
-import org.bitcoinj.base.DefaultAddressParser
-import org.bitcoinj.base.Network
 import org.bitcoinj.crypto.ECKey
 import org.bitcoinj.base.Sha256Hash
 import org.bitcoinj.core.Transaction
@@ -19,7 +18,7 @@ import org.consensusj.bitcoinj.wallet.BipStandardDeterministicKeyChain
  *
  */
 class HDKeychainSignerSpec extends DeterministicKeychainBaseSpec {
-    static final addressParser = new DefaultAddressParser()
+    static final addressParser = AddressParser.getDefault()
     static final Sha256Hash input_txid = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48")
     static final Utxo utxo = Utxo.of(input_txid, 0, Coin.SATOSHI);
 
@@ -49,7 +48,7 @@ class HDKeychainSignerSpec extends DeterministicKeychainBaseSpec {
 
         then:
         signedTx != null
-        signedTx.verify()
+        Transaction.verify(network, signedTx)
 
         when: "We validate the signature on the input"
         TransactionVerification.correctlySpendsInput(signedTx, 0, fromAddress)
@@ -97,7 +96,7 @@ class HDKeychainSignerSpec extends DeterministicKeychainBaseSpec {
 
         then:
         signedTx != null
-        signedTx.verify()
+        Transaction.verify(network, signedTx)
 
         when: "We validate the signature on the input"
         TransactionVerification.correctlySpendsInput(signedTx, 0, fromAddress)
@@ -136,6 +135,6 @@ class HDKeychainSignerSpec extends DeterministicKeychainBaseSpec {
     }
 
     private Address address(String addressString) {
-        return addressParser.parseAddressAnyNetwork(addressString);
+        return addressParser.parseAddress(addressString);
     }
 }

--- a/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/KeychainRoundTripStepwiseSpec.groovy
+++ b/cj-bitcoinj-util/src/test/groovy/org/consensusj/bitcoinj/signing/KeychainRoundTripStepwiseSpec.groovy
@@ -145,7 +145,7 @@ class KeychainRoundTripStepwiseSpec extends DeterministicKeychainBaseSpec  {
 
     def "The signed transaction verifies"() {
         expect: "it verifies"
-        signedTx.verify()
+        Transaction.verify(network, signedTx)
 
         when: "We validate the signature on the input"
         // Extract fromAddress out of the signing request

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/AddressDeserializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/AddressDeserializer.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.AddressParser;
-import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.core.NetworkParameters;
@@ -19,25 +18,25 @@ import java.io.IOException;
  * Deserialize bitcoinj (family) addresses
  */
 public class AddressDeserializer extends JsonDeserializer<Address> {
-    private final AddressParser.Strict addressParser;
+    private final AddressParser addressParser;
 
     /**
      * Construct an address deserializer that will deserialize addresses for any of the default supported networks.
-     * See {@link NetworkParameters} to understand what the supported networks are.
+     * See {@link Network} to understand what the supported networks are.
      */
     public AddressDeserializer() {
-        this((s) -> new DefaultAddressParser().parseAddressAnyNetwork(s));
+        this(AddressParser.getDefault());
     }
 
     /**
-     * Construct an address deserializer that validates addresses for the specified {@link NetworkParameters}.
+     * Construct an address deserializer that validates addresses for the specified {@link Network}.
      * When deserializing addresses, addresses that are not from the specified network will cause a
      * {@link InvalidFormatException} to be thrown during deserialization.
      *
      * @param network Network id to specify the only network we will deserialize addresses for.
      */
     public AddressDeserializer(Network network) {
-        this((s) -> new DefaultAddressParser().parseAddress(s, network));
+        this(AddressParser.getDefault(network));
     }
 
     /**
@@ -51,15 +50,15 @@ public class AddressDeserializer extends JsonDeserializer<Address> {
     @Deprecated
     public AddressDeserializer(NetworkParameters netParams) {
         this((netParams != null)
-                ? (s) -> new DefaultAddressParser().parseAddress(s, netParams.network())
-                : (s) -> new DefaultAddressParser().parseAddressAnyNetwork(s));
+                ? AddressParser.getDefault(netParams.network())
+                : AddressParser.getDefault());
     }
 
     /**
      * Construct an address deserializer with a custom {@link AddressParser}
      * @param addressParser parser to convert a string to an address
      */
-    public AddressDeserializer(AddressParser.Strict addressParser) {
+    public AddressDeserializer(AddressParser addressParser) {
         this.addressParser = addressParser;
     }
 

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/AddressKeyDeserializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/AddressKeyDeserializer.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.AddressParser;
-import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.core.NetworkParameters;
@@ -17,26 +16,26 @@ import java.io.IOException;
  * Key Deserializer to support using Address as the key in a Map.
  */
 public class AddressKeyDeserializer extends KeyDeserializer {
-    private final AddressParser.Strict addressParser;
+    private final AddressParser addressParser;
 
     /**
      * Construct an address deserializer that will deserialize addresses for the default supported networks.
-     * See {@link NetworkParameters} to understand what the supported networks are.
+     * See {@link Network} to understand what the supported networks are.
      */
     public AddressKeyDeserializer() {
-        this((s) -> new DefaultAddressParser().parseAddressAnyNetwork(s));
+        this(AddressParser.getDefault());
     }
 
     /**
      * Construct an address KeyDeserializer with a custom {@link AddressParser}
      * @param addressParser parser to convert a string to an address
      */
-    public AddressKeyDeserializer(AddressParser.Strict addressParser) {
+    public AddressKeyDeserializer(AddressParser addressParser) {
         this.addressParser = addressParser;
     }
 
     /**
-     * Construct an address KeyDeserializer that validates addresses for the specified {@link NetworkParameters}.
+     * Construct an address KeyDeserializer that validates addresses for the specified {@link Network}.
      * When deserializing addresses, addresses that are not from the specified network will cause a
      * {@link InvalidFormatException} to be thrown during deserialization.
      *
@@ -44,8 +43,8 @@ public class AddressKeyDeserializer extends KeyDeserializer {
      */
     public AddressKeyDeserializer(Network network) {
         this( (network != null)
-                ? (s) -> new DefaultAddressParser().parseAddress(s, network)
-                : (s) -> new DefaultAddressParser().parseAddressAnyNetwork(s));
+                ? AddressParser.getDefault(network)
+                : AddressParser.getDefault());
     }
 
     /**

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/BlockHexDeserializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/BlockHexDeserializer.java
@@ -14,20 +14,20 @@ import org.bitcoinj.core.ProtocolException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-// TODO: In (planned) bitcoinj 0.17-alpha2 Network/NetworkParameters is no longer needed to construct blocks
 /**
  * Deserializes a hex string as a Bitcoin {@link Block}
  */
 public class BlockHexDeserializer extends JsonDeserializer<Block> {
-    private final NetworkParameters netParams;
 
+    public BlockHexDeserializer() {
+    }
+
+    @Deprecated
     public BlockHexDeserializer(Network network) {
-        this.netParams = NetworkParameters.of(network);
     }
 
     @Deprecated
     public BlockHexDeserializer(NetworkParameters netParams) {
-        this.netParams = netParams;
     }
 
     @Override
@@ -37,8 +37,7 @@ public class BlockHexDeserializer extends JsonDeserializer<Block> {
             case VALUE_STRING:
                 try {
                     byte[] payload = HexUtil.hexStringToByteArray(p.getValueAsString()); // convert  to hex
-                    // TODO: return Block.read(ByteBuffer.wrap(payload));
-                    return netParams.getDefaultSerializer().makeBlock(ByteBuffer.wrap(payload));
+                    return Block.read(ByteBuffer.wrap(payload));
                 } catch (ProtocolException e) {
                     throw new InvalidFormatException(p, "Invalid Block", p.getValueAsString(), Block.class);
                 }

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/AddressGroupingItem.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/AddressGroupingItem.java
@@ -3,7 +3,6 @@ package org.consensusj.bitcoin.json.pojo;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 
 import java.util.List;
@@ -13,7 +12,7 @@ import java.util.List;
  * Note: In the JSON response this is actually an array
  */
 public class AddressGroupingItem {
-    private static final AddressParser addressParser = new DefaultAddressParser();
+    private static final AddressParser addressParser = AddressParser.getDefault();
     private final Address address;
     private final Coin balance;
     private final String account;
@@ -29,7 +28,7 @@ public class AddressGroupingItem {
         //TODO: Try to avoid using Double
         Double balanceDouble = (Double) addressItem.get(1);
         account = (addressItem.size() > 2) ? (String) addressItem.get(2) : null;
-        address = addressParser.parseAddress(addressStr, network);
+        address = addressParser.parseAddress(addressStr);
         balance = Coin.valueOf(((Double)(balanceDouble * 100000000.0)).longValue());
 
     }

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/PrevTxOutInfo.java
@@ -19,7 +19,7 @@ public class PrevTxOutInfo implements UtxoInfo {
     public PrevTxOutInfo(Sha256Hash txId, int vout, String scriptPubKey, String redeemScript, String witnessScript, Coin amount) {
         this.txId = txId;
         this.vout = vout;
-        this.scriptPubKey = new Script(HexUtil.hexStringToByteArray(scriptPubKey));
+        this.scriptPubKey = Script.parse(HexUtil.hexStringToByteArray(scriptPubKey));
         this.redeemScript = redeemScript;
         this.witnessScript = witnessScript;
         this.amount = amount;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/UnspentOutput.java
@@ -47,7 +47,7 @@ public class UnspentOutput implements UtxoInfo {
         this.vout = vout;
         this.address = address;
         this.label = label;
-        this.scriptPubKey = new Script(HexUtil.hexStringToByteArray(scriptPubKey));
+        this.scriptPubKey = Script.parse(HexUtil.hexStringToByteArray(scriptPubKey));
         this.amount = amount;
         this.confirmations = confirmations;
         this.redeemScript = redeemScript;

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/bitcore/AddressUtxoInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/bitcore/AddressUtxoInfo.java
@@ -29,7 +29,7 @@ public class AddressUtxoInfo {
         this.address = address;
         this.txid = txid;
         this.outputIndex = outputIndex;
-        this.script = new Script(HexUtil.hexStringToByteArray(script));
+        this.script = Script.parse(HexUtil.hexStringToByteArray(script));
         this.satoshis = Coin.ofSat(satoshis);
         this.height = height;
         this.coinbase = coinbase;

--- a/cj-btc-json/src/test/groovy/org/consensusj/bitcoin/json/conversion/AddressDeserializerSpec.groovy
+++ b/cj-btc-json/src/test/groovy/org/consensusj/bitcoin/json/conversion/AddressDeserializerSpec.groovy
@@ -1,8 +1,8 @@
 package org.consensusj.bitcoin.json.conversion
 
 import org.bitcoinj.base.Address
+import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.BitcoinNetwork
-import org.bitcoinj.base.DefaultAddressParser
 import spock.lang.Unroll
 
 /**
@@ -19,7 +19,7 @@ class AddressDeserializerSpec extends BaseObjectMapperSpec {
 
         where:
         fragment                                    | expectedResult
-        '"mzoXt4rLjhcfkDPPo2rDXYMHzVnKDgmk2E"'      | new DefaultAddressParser().parseAddress('mzoXt4rLjhcfkDPPo2rDXYMHzVnKDgmk2E', BitcoinNetwork.TESTNET)
+        '"mzoXt4rLjhcfkDPPo2rDXYMHzVnKDgmk2E"'      | AddressParser.getDefault(BitcoinNetwork.TESTNET).parseAddress('mzoXt4rLjhcfkDPPo2rDXYMHzVnKDgmk2E')
     }
 
     @Override

--- a/cj-btc-json/src/test/groovy/org/consensusj/bitcoin/json/pojo/RawTransactionInfoSpec.groovy
+++ b/cj-btc-json/src/test/groovy/org/consensusj/bitcoin/json/pojo/RawTransactionInfoSpec.groovy
@@ -3,7 +3,6 @@ package org.consensusj.bitcoin.json.pojo
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.Sha256Hash
 import org.bitcoinj.core.Context
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.testing.FakeTxBuilder
 import spock.lang.Specification
 
@@ -35,7 +34,7 @@ class RawTransactionInfoSpec extends Specification {
 
     def "Construct from Fake BitcoinJ transaction"() {
         given:
-        def tx = FakeTxBuilder.createFakeTx(NetworkParameters.of(BitcoinNetwork.MAINNET))
+        def tx = FakeTxBuilder.createFakeTx(BitcoinNetwork.MAINNET)
 
         when:
         def raw = new RawTransactionInfo(tx)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
@@ -48,9 +48,9 @@ class WalletSendSpec extends BaseRegTestSpec {
 
     void setupSpec() {
         BriefLogFormatter.init()
-        wallet = Wallet.createDeterministic(NetworkParameters.of(network), ScriptType.P2PKH)
-        var store = new MemoryBlockStore(NetworkParameters.of(network))
-        var chain = new BlockChain(NetworkParameters.of(network),wallet,store)
+        wallet = Wallet.createDeterministic(network, ScriptType.P2PKH)
+        var store = new MemoryBlockStore(NetworkParameters.of(network).getGenesisBlock())
+        var chain = new BlockChain(network,wallet,store)
         peerGroup = new PeerGroup(network, chain)
     }
 
@@ -149,7 +149,7 @@ class WalletSendSpec extends BaseRegTestSpec {
         when: "we create a transaction using bitcoinj"
         Coin amount = 1.btc
         Address serverWalletAddress = client.getNewAddress()
-        Transaction tx = new Transaction(NetworkParameters.of(network))
+        Transaction tx = new Transaction()
         tx.addOutput(amount, serverWalletAddress)
         SendRequest request = SendRequest.forTx(tx)
         wallet.completeTx(request)  // Find an appropriate input, calculate fees, etc.
@@ -173,7 +173,7 @@ class WalletSendSpec extends BaseRegTestSpec {
         when: "we create a transaction using the bitcoinj wallet"
         Coin amount = 1.btc
         Address rpcAddress = client.getNewAddress()
-        Transaction tx = new Transaction(NetworkParameters.of(network))
+        Transaction tx = new Transaction()
         tx.addOutput(amount, rpcAddress)
         SendRequest request = SendRequest.forTx(tx)
         wallet.completeTx(request)  // Find an appropriate input, calculate fees, etc.

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WorkingWithContractsSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WorkingWithContractsSpec.groovy
@@ -56,9 +56,9 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
 
     def "Client has a Bitcoinj Wallet with some funds"() {
         when: "Create a bitcoinj wallet"
-        wallet = new Wallet(params)
+        wallet = Wallet.createBasic(BitcoinNetwork.REGTEST)
         wallet.setCoinSelector(new AllowUnconfirmedCoinSelector())
-        def store = new MemoryBlockStore(params)
+        def store = new MemoryBlockStore(params.getGenesisBlock())
         chain = new BlockChain(params,wallet,store)
         peerGroup = new PeerGroup(params, chain)
         peerGroup.addWallet(wallet)
@@ -73,7 +73,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         given:
         def fundingAddress = createFundedAddress(walletStartAmount + 0.1.btc)
         def walletKey = new ECKey()
-        def walletAddr = walletKey.toAddress(params)
+        def walletAddr = walletKey.toAddress(P2PKH, BitcoinNetwork.REGTEST)
         wallet.importKey(walletKey)
 
         when: "we send coins to the wallet and write a block"
@@ -107,7 +107,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         clientKey = new ECKey();
 
         and: "Prepare a template for the contract."
-        Transaction contract = new Transaction(params)
+        Transaction contract = new Transaction()
         List<ECKey> keys = Arrays.asList(clientKey, serverKey)
         // Create a 2-of-2 multisig output script.
         Script script = ScriptBuilder.createMultiSigOutputScript(2, keys)
@@ -149,7 +149,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         Coin value = multisigOutput.getValue();
 
         // OK, now build a transaction that spends the money back to the client.
-        Transaction spendTx = new Transaction(params);
+        Transaction spendTx = new Transaction();
         spendTx.addOutput(value, clientKey);
         spendTx.addInput(multisigOutput);
 
@@ -172,7 +172,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
 
         when:
         // Client side code.
-        Transaction spendTx = new Transaction(params);
+        Transaction spendTx = new Transaction();
         spendTx.addOutput(txAmount, clientKey);
         TransactionInput input = spendTx.addInput(multisigOutput);
         Sha256Hash sighash = spendTx.hashForSignature(0, multisigScript, Transaction.SigHash.ALL, false);

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
@@ -111,7 +111,7 @@ class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
         result.getHex() != null
 
         when: "we deserialize the signed tx"
-        var signed = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
+        var signed = Transaction.read(ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
 
         then:
         signed != null
@@ -139,7 +139,7 @@ class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
         Map<String, String> toOutput = Map.of(toAddr.toString(), sendAmount.toPlainString())
         Map<String, String> changeOutput = Map.of(spvWalletAddress.toString(), (funds - (sendAmount + 0.1.btc)).toPlainString());
         var hex = appKitService.createrawtransaction(List.of(inp), List.of(toOutput, changeOutput)).join()
-        var utx = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(hex)));
+        var utx = Transaction.read(ByteBuffer.wrap(hexFormatter.parseHex(hex)));
 
         then:
         utx.getOutputSum() >= 0.9.btc
@@ -153,7 +153,7 @@ class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
         result.getHex() != null
 
         when: "we deserialize the signed tx"
-        var signed = new Transaction(spvWalletAddress.getParameters(), ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
+        var signed = Transaction.read(ByteBuffer.wrap(hexFormatter.parseHex(result.getHex())))
 
         then:
         signed != null

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
@@ -4,7 +4,6 @@ import groovy.util.logging.Slf4j
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.ScriptType
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.crypto.ECKey
 import org.consensusj.bitcoin.json.pojo.UnspentOutput
@@ -84,7 +83,7 @@ class WalletSigningServiceRegTestSpec extends BaseRegTestSpec {
 
         when: "we deserialize it"
         var raw = ByteBuffer.wrap(serialized);
-        var dTx = new Transaction(NetworkParameters.of(network), raw)
+        var dTx = Transaction.read(raw)
         var req = RawTransactionSigningRequest.ofTransaction(network, dTx)
 
         then: "it has all the information we need to prepare it for signing"

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
@@ -58,7 +58,7 @@ class BitcoinRawTransactionSpec extends BaseRegTestSpec {
     def "Verify bitcoinj can round-trip the raw transaction"() {
         when: "We parse the transaction"
         var buffer = ByteBuffer.wrap(HexUtil.hexStringToByteArray(rawTransactionHex))
-        var transaction = new Transaction(client().getNetParams(), buffer)
+        var transaction = Transaction.read(buffer)
         var roundtrip = HexUtil.bytesToHexString(transaction.bitcoinSerialize())
 
         then:

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
@@ -44,7 +44,7 @@ class BareMultisigSpec extends TxTestBaseSpec {
         def ingredients = createIngredients(10.btc)
 
         when: "we build a transaction"
-        contract = new Transaction(params)
+        contract = new Transaction()
 
         // 2-of-2 multisig
         // Note that at this point it is not necessary to have the private key for either/any of the keys.
@@ -78,7 +78,7 @@ class BareMultisigSpec extends TxTestBaseSpec {
         value == amount
 
         when: "OK, now build a transaction that spends the money back to the client."
-        Transaction spendTx = new Transaction(params);
+        Transaction spendTx = new Transaction();
         spendTx.addOutput(amount2, clientKey)
         spendTx.addInput(multisigOutput)
 
@@ -101,7 +101,7 @@ class BareMultisigSpec extends TxTestBaseSpec {
         TransactionOutput multisigOutput = contract.getOutput(0)
 
         when: "we build a transaction"
-        Transaction spendTx = new Transaction(params)
+        Transaction spendTx = new Transaction()
         spendTx.addOutput(amount2, clientKey)
         TransactionInput input = spendTx.addInput(multisigOutput)
         Sha256Hash sighash = spendTx.hashForSignature(0,

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
@@ -24,7 +24,7 @@ class OpReturnSpec extends TxTestBaseSpec {
         Coin amount = 9.999.btc
 
         when: "we build a transaction"
-        Transaction tx = new Transaction(params)
+        Transaction tx = new Transaction()
         Script script = new ScriptBuilder()
                 .op(ScriptOpCodes.OP_RETURN)
                 .data(testData)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
@@ -23,7 +23,7 @@ class P2PKHSpec extends TxTestBaseSpec {
         def destAddress = client.getNewAddress()
 
         when: "we build a transaction"
-        Transaction tx = new Transaction(params)
+        Transaction tx = new Transaction()
         tx.addOutput(amount, destAddress)
         // Assume only 1 (first) outpoint is needed (assuming utxos made by createIngredients are big enough)
         tx.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), ingredients.privateKey);

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/TxTestBaseSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/TxTestBaseSpec.groovy
@@ -2,17 +2,9 @@ package org.consensusj.bitcoin.rpc.tx
 
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.jsonrpc.groovy.test.JTransactionTestSupport
-import org.bitcoinj.core.NetworkParameters
-import spock.lang.Shared
 
 /**
  * Base test class for testing bitcoinj transactions via P2P and RPC on RegTest
  */
 abstract class TxTestBaseSpec extends BaseRegTestSpec implements JTransactionTestSupport {
-    @Shared
-    NetworkParameters params
-
-    void setupSpec() {
-        params = NetworkParameters.of(client.getNetwork())
-    }
 }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -1,8 +1,8 @@
 package org.consensusj.bitcoin.jsonrpc;
 
 import com.fasterxml.jackson.databind.JavaType;
+import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.BitcoinNetwork;
-import org.bitcoinj.base.DefaultAddressParser;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.BitcoinNetworkParams;
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 public class BitcoinExtendedClient extends BitcoinClient {
     private static final Logger log = LoggerFactory.getLogger(BitcoinExtendedClient.class);
 
-    public static final Address DEFAULT_REGTEST_MINING_ADDRESS = new DefaultAddressParser().parseAddressAnyNetwork("mwQA8f4pH23BfHyy4zf8mgAyeNu5uoy6GU");
+    public static final Address DEFAULT_REGTEST_MINING_ADDRESS = AddressParser.getDefault().parseAddress("mwQA8f4pH23BfHyy4zf8mgAyeNu5uoy6GU");
     private static final BigInteger NotSoPrivatePrivateInt = new BigInteger(1, Hex.decode("180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19"));
     private static final String RegTestMiningAddressLabel = "RegTestMiningAddress";
     public static final String REGTEST_WALLET_NAME = "consensusj-regtest-wallet";
@@ -399,7 +399,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
     public Transaction createSignedTransaction(ECKey fromKey, List<TransactionOutput> outputs) throws JsonRpcStatusException, IOException {
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, getNetwork());
 
-        Transaction tx = new Transaction(getNetParams());   // Create a new transaction
+        Transaction tx = new Transaction();   // Create a new transaction
         outputs.forEach(tx::addOutput);                     // Add all requested outputs to it
 
         // Fetch all UTXOs for the sending Address
@@ -444,7 +444,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      */
     public Transaction createSignedTransaction(ECKey fromKey, Address toAddress, Coin amount) throws JsonRpcStatusException, IOException {
         List<TransactionOutput> outputs = List.of(
-                new TransactionOutput(getNetParams(), null, amount, toAddress));
+                new TransactionOutput(null, amount, toAddress));
         return createSignedTransaction(fromKey, outputs);
     }
 
@@ -499,7 +499,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
      * @return The *bitcoinj* object  (that's out-POINT)
      */
     private TransactionOutPoint unspentToTransactionOutpoint(UnspentOutput unspentOutput) {
-        return new TransactionOutPoint(getNetParams(), unspentOutput.getVout(), unspentOutput.getTxid());
+        return new TransactionOutPoint(unspentOutput.getVout(), unspentOutput.getTxid());
     }
 
     /**

--- a/cj-btc-rx-jsonrpc/src/main/java/org/consensusj/bitcoin/rx/zeromq/RxBitcoinZmqBinaryService.java
+++ b/cj-btc-rx-jsonrpc/src/main/java/org/consensusj/bitcoin/rx/zeromq/RxBitcoinZmqBinaryService.java
@@ -19,8 +19,6 @@ import static org.consensusj.bitcoin.rx.zeromq.BitcoinZmqMessage.Topic.*;
  * TODO: Support using all topics, notjust `rawblock` and `rawtx`.
  */
 public class RxBitcoinZmqBinaryService implements RxBlockchainBinaryService, Closeable {
-
-    protected final Network network;
     protected final RxBitcoinClient client;
     private final RxBitcoinSinglePortZmqService blockService;
     private final RxBitcoinSinglePortZmqService txService;
@@ -36,7 +34,6 @@ public class RxBitcoinZmqBinaryService implements RxBlockchainBinaryService, Clo
 
     public RxBitcoinZmqBinaryService(RxBitcoinClient client) {
         this.client = client;
-        this.network = client.getNetwork();
         threadFactory = new BitcoinClientThreadFactory(Context.getOrCreate(), "RxBitcoinZmq Thread");
 
         // TODO: Create background thread to look for the ZMQ Ports

--- a/cj-btc-rx-peergroup/src/main/java/org/consensusj/bitcoin/rx/peergroup/RxPeerGroup.java
+++ b/cj-btc-rx-peergroup/src/main/java/org/consensusj/bitcoin/rx/peergroup/RxPeerGroup.java
@@ -1,6 +1,5 @@
 package org.consensusj.bitcoin.rx.peergroup;
 
-import org.bitcoinj.base.Network;
 import org.consensusj.bitcoin.json.pojo.ChainTip;
 import io.reactivex.rxjava3.processors.PublishProcessor;
 import org.bitcoinj.core.Block;
@@ -45,11 +44,6 @@ public class RxPeerGroup implements RxBlockchainService {
         this.transactionProcessor = PublishProcessor.create();
         this.blockHeightProcessor = PublishProcessor.create();
         //start();   // TODO: See start()
-    }
-
-    @Override
-    public Network network() {
-        return peerGroup.getVersionMessage().getParams().network();
     }
 
     /**

--- a/cj-btc-rx/src/main/java/org/consensusj/bitcoin/rx/RxBlockchainService.java
+++ b/cj-btc-rx/src/main/java/org/consensusj/bitcoin/rx/RxBlockchainService.java
@@ -1,6 +1,5 @@
 package org.consensusj.bitcoin.rx;
 
-import org.bitcoinj.base.Network;
 import org.consensusj.bitcoin.json.pojo.ChainTip;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Sha256Hash;
@@ -21,7 +20,6 @@ import java.io.Closeable;
  * published data type.
  */
 public interface RxBlockchainService extends Closeable {
-    Network network();
     Publisher<Transaction> transactionPublisher();
     Publisher<Sha256Hash> transactionHashPublisher();
     Publisher<Block> blockPublisher();

--- a/cj-nmc-jsonrpc/src/test/groovy/org/consensusj/namecoin/jsonrpc/core/NMCAddressSpec.groovy
+++ b/cj-nmc-jsonrpc/src/test/groovy/org/consensusj/namecoin/jsonrpc/core/NMCAddressSpec.groovy
@@ -2,13 +2,10 @@ package org.consensusj.namecoin.jsonrpc.core
 
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.ScriptType
-import org.bitcoinj.core.NetworkParameters
 import org.bitcoinj.crypto.DumpedPrivateKey
 import org.bitcoinj.crypto.ECKey
 import org.bitcoinj.base.LegacyAddress
 import spock.lang.Specification
-
-import java.nio.ByteBuffer
 
 /**
  * Tests of creating Namecoin addresses and conversion between BTC and NMC
@@ -16,7 +13,7 @@ import java.nio.ByteBuffer
  * These tests were ported from some earlier work with Litecoin and the prefixes and logic have not been double-checked.
  */
 class NMCAddressSpec extends Specification {
-    static final mainNetParams = NetworkParameters.of(BitcoinNetwork.MAINNET)
+    static final mainNet = BitcoinNetwork.MAINNET
     static final nmcNetParams = NMCMainNetParams.get()
     static final NotSoPrivatePrivateKey = new BigInteger(1, '180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19'.decodeHex());
     static final nmcPrefixRange = 'M'..'N'
@@ -93,7 +90,7 @@ class NMCAddressSpec extends Specification {
         def nmcAddress = key.toAddress(ScriptType.P2PKH, NameCoinNetwork.MAINNET)
         def btcAddress = key.toAddress(ScriptType.P2PKH, BitcoinNetwork.MAINNET)
         def nmcExportKey = key.getPrivateKeyEncoded(nmcNetParams)
-        def btcExportKey = key.getPrivateKeyEncoded(mainNetParams)
+        def btcExportKey = key.getPrivateKeyEncoded(mainNet)
 
         then:
         nmcAddress.toString() == "NBJC6raC4rfxAA7KTgXwFAgV2PMercURwH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 consensusjVersion = 0.7.0-SNAPSHOT
 
-bitcoinjVersion = 0.17-alpha1
+bitcoinjVersion = 0.17-alpha2
 rxJavaVersion = 3.1.6
 groovyVersion = 4.0.13
 spockVersion = 2.3-groovy-4.0

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -9,7 +9,7 @@ ext.javadocSpec = {
             "https://fasterxml.github.io/jackson-databind/javadoc/2.14/"
     ]
 
-    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("rc")) {
+    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("rc")) {
         javaDocLinks.add("https://bitcoinj.org/javadoc/${bitcoinjVersion}/".toString())
     }
 


### PR DESCRIPTION
* Transaction constructors no longer use NetworkParameters
* Transaction.read to create a Transaction from a ByteBuffer
* Script.parse to read a script from a byte[]
* Changes to AddressParser
* RpcClientModule no longer requires a network to construct
* BitcoinClient now always initializes JSON mapper in constructor
* Much less use of NetworkParameters in general
* RxBlockchainService interface no longer includes network()