### PR TITLE
Fix most Java, Groovy deprecation warnings

### DIFF
--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/TransactionSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/TransactionSpec.groovy
@@ -42,10 +42,10 @@ class TransactionSpec extends Specification {
         Transaction tx = new Transaction()
         TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id)
         tx.addOutput(txAmount, toAddr)
-        tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), fromKey);
+        tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), null, fromKey);
 
         and: "We serialize the transaction"
-        var rawTx = ByteBuffer.wrap(tx.bitcoinSerialize())
+        var rawTx = ByteBuffer.wrap(tx.serialize())
 
         and: "We parse it into a new Transaction object"
         Transaction parsedTx = Transaction.read(rawTx)
@@ -58,8 +58,8 @@ class TransactionSpec extends Specification {
         parsedTx.inputs.size() == 1
 
         with (parsedTx.inputs.get(0)) {
-            outpoint.hash == utxo_id
-            outpoint.index == 0
+            outpoint.hash() == utxo_id
+            outpoint.index() == 0
             scriptBytes.length == 0x8a
             scriptSig != null       // script needs to be broken down more and compared here
             sequenceNumber == 0xffffffff
@@ -73,7 +73,7 @@ class TransactionSpec extends Specification {
             scriptPubKey != null    // script needs to be broken down more and compared here
         }
 
-        parsedTx.lockTime == 0
+        parsedTx.lockTime().rawValue() == 0
 
         when: "We validate the signature on each input"
         def inputs = parsedTx.getInputs();
@@ -82,7 +82,7 @@ class TransactionSpec extends Specification {
             TransactionInput input = inputs.get(i);
             Script scriptSig = input.getScriptSig();
             Script scriptPubKey = ScriptBuilder.createOutputScript(fromAddress);
-            scriptSig.correctlySpends(parsedTx, i, scriptPubKey, Script.ALL_VERIFY_FLAGS);
+            scriptSig.correctlySpends(parsedTx, i, null, null, scriptPubKey, Script.ALL_VERIFY_FLAGS);
         }
 
         then: "Signature is valid"

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/WalletSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/WalletSpec.groovy
@@ -34,7 +34,7 @@ class WalletSpec  extends Specification {
         ByteArrayOutputStream stream = new ByteArrayOutputStream(4_000_000)
 
         when:
-        wallet.addWatchedAddresses(addresses, 0)
+        wallet.addWatchedAddresses(addresses)
 
         and:
         wallet.saveToFileStream(stream)

--- a/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/OpReturnSpec.groovy
+++ b/cj-bitcoinj-spock/src/test/groovy/org/consensusj/bitcoinj/spock/tx/OpReturnSpec.groovy
@@ -34,16 +34,16 @@ class OpReturnSpec extends BaseTransactionSpec {
 
 
         and: "We serialize the transaction"
-        byte[] rawTx = tx.bitcoinSerialize()
+        byte[] rawTx = tx.serialize()
 
         and: "We parse it into a new Transaction object"
         Transaction parsedTx = Transaction.read(ByteBuffer.wrap(rawTx))
 
         then: "we can retrieve the data"
-        with (parsedTx.getOutput(0).scriptPubKey.chunks.get(0)) {
+        with (parsedTx.getOutput(0).scriptPubKey.chunks().get(0)) {
             opcode == ScriptOpCodes.OP_RETURN
         }
-        with (parsedTx.getOutput(0).scriptPubKey.chunks.get(1)) {
+        with (parsedTx.getOutput(0).scriptPubKey.chunks().get(1)) {
             opcode == opCodeFromLength(testData.length);
             data == testData
         }

--- a/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/RawTransactionSigningRequest.java
+++ b/cj-bitcoinj-util/src/main/java/org/consensusj/bitcoinj/signing/RawTransactionSigningRequest.java
@@ -22,7 +22,7 @@ public class RawTransactionSigningRequest {
 
     public static RawTransactionSigningRequest ofTransaction(Transaction transaction) {
         List<RawInput> inputs = transaction.getInputs().stream()
-                .map(i -> new RawInput(i.getOutpoint().hash(), (int) i.getOutpoint().getIndex(), i.getScriptSig()))
+                .map(i -> new RawInput(i.getOutpoint().hash(), (int) i.getOutpoint().index(), i.getScriptSig()))
                 .collect(Collectors.toList());
         List<TransactionOutputData> outputs = transaction.getOutputs().stream()
                 .map(TransactionOutputData::fromTxOutput)

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/TransactionHexSerializer.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/conversion/TransactionHexSerializer.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class TransactionHexSerializer extends JsonSerializer<Transaction> {
     @Override
     public void serialize(Transaction value, JsonGenerator gen, SerializerProvider serializers) throws IOException, JsonProcessingException {
-        gen.writeString(HexUtil.bytesToHexString(value.bitcoinSerialize()));
+        gen.writeString(HexUtil.bytesToHexString(value.serialize()));
     }
 
 }

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/RawTransactionInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/RawTransactionInfo.java
@@ -59,7 +59,7 @@ public class RawTransactionInfo {
      * @param transaction A bitcoinj confirmed or unconfirmed transaction
      */
     public RawTransactionInfo(Transaction transaction) {
-        this.hex = HexUtil.bytesToHexString(transaction.bitcoinSerialize());
+        this.hex = HexUtil.bytesToHexString(transaction.serialize());
         this.txid = transaction.getTxId();
         this.version = transaction.getVersion();
         this.lockTime = transaction.lockTime();
@@ -69,7 +69,7 @@ public class RawTransactionInfo {
         this.blocktime = this.time; // same as time (see API doc)
         vin = transaction.getInputs().stream()
                 .map(input -> new Vin(txid,
-                        input.getOutpoint().getIndex(),
+                        input.getOutpoint().index(),
                         input.getScriptSig().toString(),
                         input.getSequenceNumber())
                 )

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/SignedRawTransaction.java
@@ -13,7 +13,7 @@ public class SignedRawTransaction {
     private final boolean complete;
 
     public static SignedRawTransaction of(Transaction transaction) {
-        return new SignedRawTransaction(transaction.bitcoinSerialize(), true);
+        return new SignedRawTransaction(transaction.serialize(), true);
     }
 
     @JsonCreator

--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BlockCypherSyncing.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BlockCypherSyncing.groovy
@@ -11,7 +11,8 @@ import org.consensusj.bitcoin.jsonrpc.test.BlockchainSyncing
 interface BlockCypherSyncing extends BlockchainSyncing {
 
     default int getReferenceBlockHeight() {
-        int height = new JsonSlurper().parse(new URL("https://api.blockcypher.com/v1/btc/main")).height
+        URL queryUrl = URI.create("https://api.blockcypher.com/v1/btc/main").toURL()
+        int height = new JsonSlurper().parse(queryUrl).height
         return height
     }
 }

--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BlockchainDotInfoSyncing.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/BlockchainDotInfoSyncing.groovy
@@ -9,7 +9,8 @@ import org.consensusj.bitcoin.jsonrpc.test.BlockchainSyncing
 interface BlockchainDotInfoSyncing extends BlockchainSyncing {
 
     default int getReferenceBlockHeight() {
-        int height = new JsonSlurper().parse(new URL("https://blockchain.info/latestblock")).height
+        URL latestBlockUrl = URI.create("https://blockchain.info/latestblock").toURL()
+        int height = new JsonSlurper().parse(latestBlockUrl).height
         return height
     }
 }

--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
@@ -56,7 +56,7 @@ trait JTransactionTestSupport implements BTCTestSupport {
         if (peerGroup == null) {
             setupPeerGroup()
         }
-        Transaction sentTx = peerGroup.broadcastTransaction(tx).future().get();
+        Transaction sentTx = peerGroup.broadcastTransaction(tx).awaitRelayed().get().transaction()
         // Wait for it to show up on server as unconfirmed
         waitForUnconfirmedTransaction(sentTx.txId)
         client.generateBlocks(1)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/alpha/AlphaSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/alpha/AlphaSpec.groovy
@@ -114,12 +114,12 @@ class AlphaSpec extends Specification {
         def result = client.settxfee(0)
         def destinationConfidentialAddress = client.getnewaddress()
         def destinationAddress = client.validateaddress(destinationConfidentialAddress).unconfidential
-        Transaction tx = new Transaction(netParams)
+        Transaction tx = new Transaction()
         tx.addOutput(testAmount.btc, Address.fromBase58(netParams, destinationAddress))
         TransactionOutPoint utxo = new TransactionOutPoint(netParams, 0, Sha256Hash.of(txid.decodeHex()))
 //        tx.addSignedInput(utxo, ScriptBuilder.createOutputScript(Address.fromBase58(netParams, fundedAddress)), key)
-        tx.addInput(utxo.hash, utxo.index, ScriptBuilder.createOutputScript(Address.fromBase58(netParams, fundedAddress)))
-        def signed = client.signrawtransaction(tx.bitcoinSerialize().encodeHex().toString())
+        tx.addInput(utxo.hash(), utxo.index(), ScriptBuilder.createOutputScript(Address.fromBase58(netParams, fundedAddress)))
+        def signed = client.signrawtransaction(tx.serialize().encodeHex().toString())
         def tx2id = client.sendrawtransaction(signed.hex)
 
         then:

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WorkingWithContractsSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WorkingWithContractsSpec.groovy
@@ -60,7 +60,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         wallet.setCoinSelector(new AllowUnconfirmedCoinSelector())
         def store = new MemoryBlockStore(params.getGenesisBlock())
         chain = new BlockChain(params,wallet,store)
-        peerGroup = new PeerGroup(params, chain)
+        peerGroup = new PeerGroup(BitcoinNetwork.REGTEST, chain)
         peerGroup.addWallet(wallet)
         peerGroup.start()
 
@@ -127,7 +127,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         when: "Broadcast"
         // Broadcast and wait for it to propagate across the network.
         // It should take a few seconds unless something went wrong.
-        broadcastTx = peerGroup.broadcastTransaction(req.tx).broadcast().get()
+        broadcastTx = peerGroup.broadcastTransaction(req.tx).broadcastAndAwaitRelay().get().transaction()
 
         then:
         broadcastTx != null
@@ -203,7 +203,7 @@ class WorkingWithContractsSpec extends BaseRegTestSpec {
         when: "Broadcast"
         // Broadcast and wait for it to propagate across the network.
         // It should take a few seconds unless something went wrong.
-        broadcastTx = peerGroup.broadcastTransaction(spendTx).broadcast().get()
+        broadcastTx = peerGroup.broadcastTransaction(spendTx).broadcastAndAwaitRelay().get().transaction()
 
         then:
         broadcastTx != null

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
@@ -103,7 +103,7 @@ class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
         utx.getOutputSum() >= 0.9.btc
 
         when: "we send the utx to appKitService for signing"
-        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.bitcoinSerialize())).join()
+        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.serialize())).join()
 
         then:
         result != null
@@ -145,7 +145,7 @@ class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
         utx.getOutputSum() >= 0.9.btc
 
         when: "we send the utx to appKitService for signing"
-        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.bitcoinSerialize())).join()
+        var result = appKitService.signrawtransactionwithwallet(hexFormatter.formatHex(utx.serialize())).join()
 
         then:
         result != null

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
@@ -59,7 +59,7 @@ class BitcoinRawTransactionSpec extends BaseRegTestSpec {
         when: "We parse the transaction"
         var buffer = ByteBuffer.wrap(HexUtil.hexStringToByteArray(rawTransactionHex))
         var transaction = Transaction.read(buffer)
-        var roundtrip = HexUtil.bytesToHexString(transaction.bitcoinSerialize())
+        var roundtrip = HexUtil.bytesToHexString(transaction.serialize())
 
         then:
         rawTransactionHex == roundtrip

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
@@ -52,7 +52,7 @@ class BareMultisigSpec extends TxTestBaseSpec {
         Script script = ScriptBuilder.createMultiSigOutputScript(2, [clientKey, serverKey])
         contract.addOutput(amount, script)
         // Assume only 1 (first) outpoint is needed (assuming utxos made by createIngredients are big enough)
-        contract.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), ingredients.privateKey)
+        contract.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), null, ingredients.privateKey)
 
         and: "send via P2P and generate a block"
         Transaction sentTx = submitRPC(contract)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
@@ -32,16 +32,16 @@ class OpReturnSpec extends TxTestBaseSpec {
         tx.addOutput(amount, script)
 
         // Assume only 1 (first) outpoint is needed (assuming utxos made by createIngredients are big enough)
-        tx.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), ingredients.privateKey);
+        tx.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), null, ingredients.privateKey);
 
         and: "send via submitMethod [P2P, RPC] and generate a block"
         Transaction sentTx = submitMethod.apply(tx)
 
         then: "we can retrieve and verify the data"
-        with (sentTx.getOutput(0).scriptPubKey.chunks.get(0)) {
+        with (sentTx.getOutput(0).scriptPubKey.chunks().get(0)) {
             opcode == ScriptOpCodes.OP_RETURN
         }
-        with (sentTx.getOutput(0).scriptPubKey.chunks.get(1)) {
+        with (sentTx.getOutput(0).scriptPubKey.chunks().get(1)) {
             opcode == opCodeFromLength(testData.length);
             data == testData
         }

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
@@ -26,7 +26,7 @@ class P2PKHSpec extends TxTestBaseSpec {
         Transaction tx = new Transaction()
         tx.addOutput(amount, destAddress)
         // Assume only 1 (first) outpoint is needed (assuming utxos made by createIngredients are big enough)
-        tx.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), ingredients.privateKey);
+        tx.addSignedInput(ingredients.outPoints.get(0), ScriptBuilder.createOutputScript(ingredients.address), null, ingredients.privateKey);
 
         and: "send via submitMethod [P2P, RPC] and generate a block"
         Transaction sentTx = submitMethod.apply(tx)

--- a/cj-nmc-jsonrpc/src/test/groovy/org/consensusj/namecoin/jsonrpc/core/NMCAddressSpec.groovy
+++ b/cj-nmc-jsonrpc/src/test/groovy/org/consensusj/namecoin/jsonrpc/core/NMCAddressSpec.groovy
@@ -85,11 +85,11 @@ class NMCAddressSpec extends Specification {
         def nmcPrivKeyString = "5JAHPeEsCHHm9xB51LvJW11bbGdu7yVWeaAtLJ8nac3odmqmyTx"
 
         when:
-        def nmcPrivateKey = DumpedPrivateKey.fromBase58(nmcNetParams, nmcPrivKeyString)
+        def nmcPrivateKey = DumpedPrivateKey.fromBase58(nmcNetParams.network(), nmcPrivKeyString)
         def key = nmcPrivateKey.getKey()
         def nmcAddress = key.toAddress(ScriptType.P2PKH, NameCoinNetwork.MAINNET)
         def btcAddress = key.toAddress(ScriptType.P2PKH, BitcoinNetwork.MAINNET)
-        def nmcExportKey = key.getPrivateKeyEncoded(nmcNetParams)
+        def nmcExportKey = key.getPrivateKeyEncoded(nmcNetParams.network())
         def btcExportKey = key.getPrivateKeyEncoded(mainNet)
 
         then:


### PR DESCRIPTION
This should fix all bitcoinj and JDK related warnings.

The only remaining warnings are related to XChange and will be handled separately/later.