### PR TITLE
WIP: Upgrade to Gradle 9.0.0

### DIFF
--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -1,7 +1,7 @@
-configurations {
-    integrationTestImplementation.extendsFrom testImplementation
-    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
-}
+//configurations {
+//    integrationTestImplementation.extendsFrom testImplementation
+//    integrationTestRuntimeOnly.extendsFrom testRuntimeOnly
+//}
 
 dependencies {
     testImplementation project(':cj-btc-jsonrpc-gvy')
@@ -24,21 +24,21 @@ dependencies {
 }
 
 // Test Structure
-sourceSets {
-    integrationTest {
-        compileClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.main.output
-        java {
-            srcDir 'src/integ/java'
-        }
-        groovy {
-            srcDir 'src/integ/groovy'
-        }
-        resources {
-            srcDir 'src/integ/resources'
-        }
-    }
-}
+//sourceSets {
+//    integrationTest {
+//        compileClasspath += sourceSets.main.output
+//        runtimeClasspath += sourceSets.main.output
+//        java {
+//            srcDir 'src/integ/java'
+//        }
+//        groovy {
+//            srcDir 'src/integ/groovy'
+//        }
+//        resources {
+//            srcDir 'src/integ/resources'
+//        }
+//    }
+//}
 
 def infuraApiKeyOrEmpty = System.env.INFURA_API_KEY ?: project.findProperty('infuraApiKey') ?: ''
 
@@ -51,12 +51,22 @@ test {
     }
 }
 
-tasks.register('integrationTest', Test) {
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-    testLogging.showStandardStreams = true
+testing {
+    suites {
+        integrationTest(JvmTestSuite) {
+            dependencies {
+                implementation project()
+            }
+        }
+    }
 }
+
+//tasks.register('integrationTest', Test) {
+//    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+//    classpath = sourceSets.integrationTest.runtimeClasspath
+//    outputs.upToDateWhen { false }
+//    testLogging.showStandardStreams = true
+//}
 
 tasks.register('regTest', Test) {
     description = 'Runs integration tests against Bitcoin Core in regtest mode'

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,7 +43,7 @@ if (JavaVersion.current().compareTo(JavaVersion.VERSION_17) < 0) {
 if (JavaVersion.current().compareTo(JavaVersion.VERSION_21) >= 0) {
     System.err.println "Including JDK 21 modules because Java is ${JavaVersion.current()}"
     include 'consensusj-jsonrpc-cli'            // JSON-RPC CLI library and tool
-    include 'cj-btc-cli'                        // Bitcoin JSON-RPC CLI
+//    include 'cj-btc-cli'                        // Bitcoin JSON-RPC CLI
 } else {
     System.err.println "Skipping JDK 21 modules, currently running Java ${JavaVersion.current()}"
 }


### PR DESCRIPTION
Note that the cj-btc-cli module is currently disabled and cj-btc-jsonrpc-integ-test is in a hacked-up state.

It looks like the main issue is the ad-hoc mechanism we used to configure integrationTest conflicts with built-in mechanism  that should be used instead.