### PR TITLE
Handle warning == null in wallet RPCs 

### DIFF
--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
@@ -20,13 +20,13 @@ class CreateWalletSpec extends BaseRegTestSpec {
 
         then: "creation was successful"
         createResult.name == walletName
-        createResult.warning == ""
+        createResult.warning == null || createResult.warning == ""
 
         when: "we unload the wallet"
         var unloadResult = walletClient.unloadWallet()
 
         then: "it works"
-        unloadResult.warning == ""
+        unloadResult.warning == null || unloadResult.warning == ""
     }
 
     @Requires({ instance.clientInstance.getServerVersion() >= 230000})
@@ -40,12 +40,12 @@ class CreateWalletSpec extends BaseRegTestSpec {
 
         then: "creation was successful"
         createResult.name == walletName
-        createResult.warning == ""
+        createResult.warning == null || createResult.warning == ""
 
         when: "we unload the wallet"
         var unloadResult = walletClient.unloadWallet()
 
         then: "it works"
-        unloadResult.warning == ""
+        unloadResult.warning == null || unloadResult.warning == ""
     }
 }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -167,7 +167,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
                     // Create a (non-descriptor) wallet
                     ? createWallet(name, false, false, null, null, false, null, null)
                     : createWallet(name, false, false, null, null);
-        if (result.getWarning().isEmpty()) {
+        if (result.getWarning() == null || result.getWarning().isEmpty()) {
             log.info("Created REGTEST wallet: \"{}\"", result.getName());
         } else {
             log.warn("Warning creating REGTEST wallet \"{}\": {}", result.getName(), result.getWarning());


### PR DESCRIPTION
In Bitcoin Core 29 (and sooner maybe) result.getWarning() can be `null` where it was previously `""`. Fix tests to handle both cases.