### PR TITLE
WIP BitcoinClient: sendrawtransaction maxburnamount

### DIFF
--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
@@ -748,7 +748,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(Transaction tx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate);
+        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate, Coin.FIFTY_COINS);  // hack: add maxburnamount
     }
 
     /**
@@ -763,7 +763,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(String hexTx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate);
+        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate, Coin.FIFTY_COINS); // hack: add maxburnamount
     }
 
     /**


### PR DESCRIPTION
Recent bitcoind (e.g. v29) has added an optional maxburnamount parameter to sendrawtransaction. Our regTests need this parameter set.

This WIP PR has a hack that always adds a maxburnamount of 50 BTC.

This needs to be updated for more correct operation.