### PR TITLE
TxOutSetInfo: switch to hash_serialized_3

### DIFF
--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutSetInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutSetInfo.java
@@ -13,7 +13,7 @@ public class TxOutSetInfo {
     private final long transactions;
     private final long txOuts;
     private final long bogoSize;
-    private final Sha256Hash hashSerialized2;
+    private final Sha256Hash hashSerialized3;
     private final long diskSize;
     private final Coin totalAmount;
 
@@ -23,7 +23,7 @@ public class TxOutSetInfo {
                         @JsonProperty("transactions")       long        transactions,
                         @JsonProperty("txouts")             long        txOuts,
                         @JsonProperty("bogosize")           long        bogoSize,
-                        @JsonProperty("hash_serialized_2")  Sha256Hash  hashSerialized2,
+                        @JsonProperty("hash_serialized_3")  Sha256Hash  hashSerialized3,
                         @JsonProperty("disk_size")          long        diskSize,
                         @JsonProperty("total_amount")       Coin        totalAmount) {
         this.height = height;
@@ -31,7 +31,7 @@ public class TxOutSetInfo {
         this.transactions = transactions;
         this.txOuts = txOuts;
         this.bogoSize = bogoSize;
-        this.hashSerialized2 = hashSerialized2;
+        this.hashSerialized3 = hashSerialized3;
         this.diskSize = diskSize;
         this.totalAmount = totalAmount;
     }
@@ -56,8 +56,8 @@ public class TxOutSetInfo {
         return bogoSize;
     }
 
-    public Sha256Hash getHashSerialized2() {
-        return hashSerialized2;
+    public Sha256Hash getHashSerialized3() {
+        return hashSerialized3;
     }
 
     public long getDiskSize() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
@@ -20,7 +20,7 @@ class GetTxOutSetInfoSpec extends BaseRegTestSpec {
         info.transactions > 0
         info.txOuts > 0
         info.bestBlock instanceof Sha256Hash
-        info.hashSerialized2 instanceof Sha256Hash
+        info.hashSerialized3 instanceof Sha256Hash
         info.totalAmount >= Coin.ZERO
         info.totalAmount <= Coin.COIN * 21_000_000
     }

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
@@ -26,7 +26,7 @@ class GetTxOutSetInfoSpec extends BaseRegTestSpec
         txOutSetInfo.transactions > 0
         txOutSetInfo.txOuts >= txOutSetInfo.transactions
         txOutSetInfo.bogoSize > txOutSetInfo.txOuts * 50
-        txOutSetInfo.hashSerialized2 != null
+        txOutSetInfo.hashSerialized3 != null
         txOutSetInfo.diskSize >= 0
         txOutSetInfo.totalAmount > Coin.ZERO && txOutSetInfo.totalAmount <= Coin.valueOf(startHeight * 50, 0)
     }


### PR DESCRIPTION
Newer Bitcoin Core (v26+) replaces `hash_serialized_2` with
`hash_serialized_3`. This PR just replaces one field with the other.

This effectively makes v26 the minimum supported Bitcoin Core, but
earlier versions might still work if you don't use txoutsetinfo.