### PR TITLE
WIP: Bitcoin Core v29 support

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -8,21 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ '17', '21', '24' ]
-        distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK ${{ matrix.java }}
+    name: RegTest ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Download Omni Core (Bitcoin Core superset)
-      run: ./test-download-omnicore-ubuntu.sh
-    - name: Set up Java
-      uses: actions/setup-java@v4
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
       with:
-        distribution: ${{ matrix.distribution }}
-        java-version: ${{ matrix.java }}
-        cache: 'gradle'
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      # pre-build the shell separately to avoid skewing the run time of the next
+      # step and have clear point of failure should the shell fail to build
+    - name: Pre-build devShell
+      run: nix build --no-link .#devShells.$(nix eval --impure --raw --expr 'builtins.currentSystem').default
     - name: Run RegTests
+      shell: 'nix develop -c bash -e {0}'
       run: ./test-run-regtest.sh
     - name: Upload RegTest results as artifact
       uses: actions/upload-artifact@v4

--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutSetInfo.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/TxOutSetInfo.java
@@ -13,7 +13,7 @@ public class TxOutSetInfo {
     private final long transactions;
     private final long txOuts;
     private final long bogoSize;
-    private final Sha256Hash hashSerialized2;
+    private final Sha256Hash hashSerialized3;
     private final long diskSize;
     private final Coin totalAmount;
 
@@ -23,7 +23,7 @@ public class TxOutSetInfo {
                         @JsonProperty("transactions")       long        transactions,
                         @JsonProperty("txouts")             long        txOuts,
                         @JsonProperty("bogosize")           long        bogoSize,
-                        @JsonProperty("hash_serialized_2")  Sha256Hash  hashSerialized2,
+                        @JsonProperty("hash_serialized_3")  Sha256Hash  hashSerialized3,
                         @JsonProperty("disk_size")          long        diskSize,
                         @JsonProperty("total_amount")       Coin        totalAmount) {
         this.height = height;
@@ -31,7 +31,7 @@ public class TxOutSetInfo {
         this.transactions = transactions;
         this.txOuts = txOuts;
         this.bogoSize = bogoSize;
-        this.hashSerialized2 = hashSerialized2;
+        this.hashSerialized3 = hashSerialized3;
         this.diskSize = diskSize;
         this.totalAmount = totalAmount;
     }
@@ -56,8 +56,8 @@ public class TxOutSetInfo {
         return bogoSize;
     }
 
-    public Sha256Hash getHashSerialized2() {
-        return hashSerialized2;
+    public Sha256Hash getHashSerialized3() {
+        return hashSerialized3;
     }
 
     public long getDiskSize() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
@@ -20,7 +20,7 @@ class GetTxOutSetInfoSpec extends BaseRegTestSpec {
         info.transactions > 0
         info.txOuts > 0
         info.bestBlock instanceof Sha256Hash
-        info.hashSerialized2 instanceof Sha256Hash
+        info.hashSerialized3 instanceof Sha256Hash
         info.totalAmount >= Coin.ZERO
         info.totalAmount <= Coin.COIN * 21_000_000
     }

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
@@ -26,7 +26,7 @@ class GetTxOutSetInfoSpec extends BaseRegTestSpec
         txOutSetInfo.transactions > 0
         txOutSetInfo.txOuts >= txOutSetInfo.transactions
         txOutSetInfo.bogoSize > txOutSetInfo.txOuts * 50
-        txOutSetInfo.hashSerialized2 != null
+        txOutSetInfo.hashSerialized3 != null
         txOutSetInfo.diskSize >= 0
         txOutSetInfo.totalAmount > Coin.ZERO && txOutSetInfo.totalAmount <= Coin.valueOf(startHeight * 50, 0)
     }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
@@ -748,7 +748,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(Transaction tx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate);
+        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate, Coin.FIFTY_COINS);  // hack: add maxburnamount
     }
 
     /**
@@ -763,7 +763,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(String hexTx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate);
+        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate, Coin.FIFTY_COINS); // hack: add maxburnamount
     }
 
     /**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756787288,
+        "narHash": "sha256-rw/PHa1cqiePdBxhF66V7R+WAP8WekQ0mCDG4CFqT8Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d0fc30899600b9b3466ddb260fd83deb486c32f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  # This currently just adds a `bitcoind` for regTest testing
+  description = "in-progress devshell support for ConsensusJ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Override bitcoind to include Berkeley DB support
+        bitcoind = pkgs.bitcoind.override { withWallet = true; };
+      in {
+        packages.bitcoind = bitcoind;
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            bitcoind
+          ];
+          shellHook = ''
+            echo "Welcome to ConsensusJ"
+            echo "  $(which bitcoind)"
+            bitcoind --version | head -n1
+          '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,12 +13,14 @@
         pkgs = import nixpkgs { inherit system; };
 
         # Override bitcoind to include Berkeley DB support
+        # This is currently broken on macOS/Darwin so devshell only works on Linux
         bitcoind = pkgs.bitcoind.override { withWallet = true; };
       in {
         packages.bitcoind = bitcoind;
 
         devShells.default = pkgs.mkShell {
           buildInputs = [
+            pkgs.jdk  # We're still building with ./gradlew, so install JDK not gradle
             bitcoind
           ];
           shellHook = ''

--- a/test-run-regtest.sh
+++ b/test-run-regtest.sh
@@ -7,13 +7,10 @@ function cleanup {
 trap cleanup EXIT
 
 # We are currently using Omni Core since it a superset of Bitcoin Core
-BITCOIND=copied-artifacts/src/omnicored
+BITCOIND=bitcoind
 DATADIR=build/regtest-datadir
 LOGDIR=logs
-OMNILOG=/tmp/omnicore.log
-
-# Assume bitcoind built elsewhere and copied without x permission
-chmod +x $BITCOIND
+#OMNILOG=/tmp/omnicore.log
 
 # Setup bitcoin conf and data dir
 mkdir -p $DATADIR
@@ -21,16 +18,17 @@ cp -n bitcoin.conf $DATADIR
 
 # setup logging
 mkdir -p $LOGDIR
-touch $OMNILOG
-ln -sf $OMNILOG $LOGDIR/omnicore.log
+#touch $OMNILOG
+#ln -sf $OMNILOG $LOGDIR/omnicore.log
 
 # Remove all regtest data
 rm -rf $DATADIR/regtest
 
 # Run bitcoind in regtest mode
 $BITCOIND -regtest -datadir=$DATADIR \
-  -addresstype=legacy -experimental-btc-balances=1 \
+  -addresstype=legacy \
   -peerbloomfilters \
+  -deprecatedrpc=create_bdb \
   -paytxfee=0.0001 -minrelaytxfee=0.00001 \
   -limitancestorcount=750 -limitdescendantcount=750 > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?


### PR DESCRIPTION
This branch PR is `master` with cherry-picks of PR #199 and PR #200 and allows the `regTest` task to work with Bitcoin Core v29.0.
