### PR TITLE
Update GHA regTest to Bitcoin Core v29 via Nix devshell

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -8,21 +8,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java: [ '17', '21', '24' ]
-        distribution: ['temurin']
       fail-fast: false
-    name: ${{ matrix.os }} JDK ${{ matrix.java }}
+    name: RegTest ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
-    - name: Download Omni Core (Bitcoin Core superset)
-      run: ./test-download-omnicore-ubuntu.sh
-    - name: Set up Java
-      uses: actions/setup-java@v4
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
       with:
-        distribution: ${{ matrix.distribution }}
-        java-version: ${{ matrix.java }}
-        cache: 'gradle'
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      # pre-build the shell separately to avoid skewing the run time of the next
+      # step and have clear point of failure should the shell fail to build
+    - name: Pre-build devShell
+      run: nix build --no-link .#devShells.$(nix eval --impure --raw --expr 'builtins.currentSystem').default
     - name: Run RegTests
+      shell: 'nix develop -c bash -e {0}'
       run: ./test-run-regtest.sh
     - name: Upload RegTest results as artifact
       uses: actions/upload-artifact@v4

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756911493,
+        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  # This currently just adds a `bitcoind` for regTest testing
+  description = "in-progress devshell support for ConsensusJ";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Override bitcoind to include Berkeley DB support
+        # This is currently broken on macOS/Darwin so regTest via devshell only works on Linux
+        bitcoind = pkgs.bitcoind.override { withWallet = true; };
+      in {
+        packages.bitcoind = bitcoind;
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.jdk  # We're still building with ./gradlew, so install JDK not gradle
+            bitcoind
+          ];
+          shellHook = ''
+            echo "Welcome to ConsensusJ"
+            echo "  $(which bitcoind)"
+            bitcoind --version | head -n1
+          '';
+        };
+      });
+}

--- a/test-run-regtest.sh
+++ b/test-run-regtest.sh
@@ -6,14 +6,10 @@ function cleanup {
 }
 trap cleanup EXIT
 
-# We are currently using Omni Core since it a superset of Bitcoin Core
-BITCOIND=copied-artifacts/src/omnicored
+# Use `bitcoind` in current PATH
+BITCOIND=bitcoind
 DATADIR=build/regtest-datadir
 LOGDIR=logs
-OMNILOG=/tmp/omnicore.log
-
-# Assume bitcoind built elsewhere and copied without x permission
-chmod +x $BITCOIND
 
 # Setup bitcoin conf and data dir
 mkdir -p $DATADIR
@@ -21,16 +17,15 @@ cp -n bitcoin.conf $DATADIR
 
 # setup logging
 mkdir -p $LOGDIR
-touch $OMNILOG
-ln -sf $OMNILOG $LOGDIR/omnicore.log
 
 # Remove all regtest data
 rm -rf $DATADIR/regtest
 
 # Run bitcoind in regtest mode
 $BITCOIND -regtest -datadir=$DATADIR \
-  -addresstype=legacy -experimental-btc-balances=1 \
+  -addresstype=legacy \
   -peerbloomfilters \
+  -deprecatedrpc=create_bdb \
   -paytxfee=0.0001 -minrelaytxfee=0.00001 \
   -limitancestorcount=750 -limitdescendantcount=750 > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?


### PR DESCRIPTION
* Add flake.nix with devshell (bitcoind regTest works only on Linux for now)
* test-run-regtest.sh: Update for Bitcoin Core v29 (bitcoind in $PATH)
* GHA regtest.yml: drop `java` matrix, Install Nix, use devShell

This will break regTests but fixes are coming soon.