### PR TITLE
BitcoinClient: add optional maxBurnAmount parameter to sendRawTransaction

### DIFF
--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
@@ -64,7 +64,7 @@ trait JTransactionTestSupport implements BTCTestSupport {
     }
 
     Transaction submitRPC(Transaction tx) {
-        Sha256Hash txid = client.sendRawTransaction(tx)
+        Sha256Hash txid = client.sendRawTransaction(tx, null, Coin.FIFTY_COINS)
         client.generateBlocks(1)
         Transaction sentTx = client.getRawTransaction(txid)
         RawTransactionInfo txinfo = client.getRawTransactionInfo(txid)

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
@@ -91,8 +91,7 @@ import java.util.stream.Stream;
  * Coin balance = client.getBalance();
  * }</pre>
  *
- * This version is written to be compatible with Bitcoin Core 0.20 and later. If used with
- * Omni Core (an enhanced version of Bitcoin Core with Omni Protocol support) Omni Core 0.11.0 or later is required.
+ * This version is written to be compatible with Bitcoin Core v26.0 and later.
  * <p>
  * Note that according to <a href="https://github.com/bitcoin/bitcoin/issues/2960">Issue #2960: Support JSON-RPC 2.0</a> Bitcoin Core
  * does not correctly follow the JSON-RPC 2.0 specification.
@@ -743,12 +742,13 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @param tx The raw transaction
      * @param maxFeeRate  Reject transactions whose fee rate is higher than this value, expressed in BTC/kB.
      *                    Set to 0 to accept any fee rate.
+     * @param maxBurnAmount Any transaction containing an unspendable output with a value greater than maxburnamount will not be submitted.
      * @return SHA256 Transaction ID
      * @throws JsonRpcStatusException JSON RPC status exception
      * @throws IOException network error
      */
-    public Sha256Hash sendRawTransaction(Transaction tx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate);
+    public Sha256Hash sendRawTransaction(Transaction tx, Coin maxFeeRate, Coin maxBurnAmount) throws JsonRpcStatusException, IOException {
+        return send("sendrawtransaction", Sha256Hash.class, tx, maxFeeRate, maxBurnAmount);
     }
 
     /**
@@ -758,12 +758,13 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @param hexTx The raw transaction as a hex-encoded string
      * @param maxFeeRate  Reject transactions whose fee rate is higher than this value, expressed in BTC/kB.
      *                    Set to 0 to accept any fee rate.
+     * @param maxBurnAmount Any transaction containing an unspendable output with a value greater than maxburnamount will not be submitted.
      * @return SHA256 Transaction ID
      * @throws JsonRpcStatusException JSON RPC status exception
      * @throws IOException network error
      */
-    public Sha256Hash sendRawTransaction(String hexTx, Coin maxFeeRate) throws JsonRpcStatusException, IOException {
-        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate);
+    public Sha256Hash sendRawTransaction(String hexTx, Coin maxFeeRate, Coin maxBurnAmount) throws JsonRpcStatusException, IOException {
+        return send("sendrawtransaction", Sha256Hash.class, hexTx, maxFeeRate, maxBurnAmount);
     }
 
     /**
@@ -775,7 +776,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(Transaction tx) throws JsonRpcStatusException, IOException {
-        return sendRawTransaction(tx, (Coin) null);
+        return sendRawTransaction(tx, null, null);
     }
 
     /**
@@ -788,7 +789,7 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
      * @throws IOException network error
      */
     public Sha256Hash sendRawTransaction(String hexTx) throws JsonRpcStatusException, IOException {
-        return sendRawTransaction(hexTx, (Coin) null);
+        return sendRawTransaction(hexTx, null, null);
     }
 
     public AddressInfo getAddressInfo(Address address) throws JsonRpcStatusException, IOException {

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -365,7 +365,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
         assert complete;
 
         String signedTxHex = signingResult.getHex();
-        Sha256Hash txid = sendRawTransaction(signedTxHex);
+        Sha256Hash txid = sendRawTransaction(signedTxHex, null, null);
 
         return txid;
     }

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
@@ -241,6 +241,6 @@ public class RegTestFundingSource implements FundingSource {
     }
 
     private Sha256Hash sendRawTransactionUnlimitedFees(String hexTx) throws IOException {
-        return client.sendRawTransaction(hexTx, Coin.ZERO);
+        return client.sendRawTransaction(hexTx, Coin.ZERO, Coin.FIFTY_COINS);
     }
 }


### PR DESCRIPTION
To err on the side of safety we default maxBurnAmount to null in SendRawTransaction(tx). (In the case of RegTest support, there are two places where we set maxBurnAmount to Coin.FIFTY_COINS)