### PR TITLE
BitcoinClient: Add importDescriptor subset functionality

### DIFF
--- a/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/MinimalDescriptor.java
+++ b/cj-btc-json/src/main/java/org/consensusj/bitcoin/json/pojo/MinimalDescriptor.java
@@ -1,0 +1,48 @@
+package org.consensusj.bitcoin.json.pojo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+/**
+ * Minimal Descriptor implementation necessary for RegTest descriptor wallet support
+ */
+public class MinimalDescriptor {
+    private final String desc;
+    private final boolean active;
+    private final Instant timestamp;
+    private final boolean internal;
+
+
+    public MinimalDescriptor(@JsonProperty("version") String desc,
+                             @JsonProperty("active") boolean active,
+                             @JsonProperty("timestamp") long timestamp,
+                             @JsonProperty("internal") boolean internal) {
+        this.desc = desc;
+        this.active = active;
+        this.timestamp = Instant.ofEpochSecond(timestamp);
+        this.internal = internal;
+    }
+
+    public MinimalDescriptor(String desc, boolean active, long timestamp) {
+        this(desc, active, timestamp, false);
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public boolean getActive() {
+        return active;
+    }
+
+    public long getTimestamp() {
+        return timestamp.getEpochSecond();
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+}
+
+

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinClient.java
@@ -15,6 +15,7 @@ import org.consensusj.bitcoin.json.pojo.BlockInfo;
 import org.consensusj.bitcoin.json.pojo.ChainTip;
 import org.consensusj.bitcoin.json.pojo.LoadWalletResult;
 import org.consensusj.bitcoin.json.pojo.MethodHelpEntry;
+import org.consensusj.bitcoin.json.pojo.MinimalDescriptor;
 import org.consensusj.bitcoin.json.pojo.NetworkInfo;
 import org.consensusj.bitcoin.json.pojo.Outpoint;
 import org.consensusj.bitcoin.json.pojo.RawTransactionInfo;
@@ -58,6 +59,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -678,7 +680,15 @@ public class BitcoinClient extends DefaultRpcClient implements ChainTipClient {
     public void importPrivKey(ECKey privateKey, String label, boolean rescan) throws JsonRpcStatusException, IOException {
         send("importprivkey", Void.class, privateKey.getPrivateKeyEncoded(this.getNetwork()).toBase58(), label, rescan);
     }
-    
+
+    // Minimal descriptor support for RegTest mining (e.g. a single address, external)
+    public JsonNode importDescriptor(String descriptor, boolean active, Instant timeStamp, String label) throws JsonRpcStatusException, IOException {
+        MinimalDescriptor minimalDescriptor = new MinimalDescriptor(descriptor, false, timeStamp.getEpochSecond(), false);
+        List<MinimalDescriptor> descriptorList = List.of(minimalDescriptor);
+        log.warn("Descriptor list: {}", this.mapper.writeValueAsString(descriptorList));
+        return send("importdescriptors", JsonNode.class, descriptorList);
+    }
+
     /**
      * Creates a raw transaction spending the given inputs to the given destinations.
      *


### PR DESCRIPTION
This is a step towards a regTest client that can mine using a descriptor wallet. Nix Darwin builds of Bitcoin Core don't include the legacy wallet, so our tests can't run against a Nix-built bitcoind on Darwin.

So a short-term goal is to do the minimum necessary to run regTest against a bitciond instance without legacy wallet support.

This PR enables regTest mining to work with descriptor wallets, but the useLegacyWallet flag is hardcoded to true because even with the mining support there are issues in some of the tests so they won't work with descriptor wallets. see the comment at line 130 in BitcoinExtendedClient.java.