### PR TITLE
Disable tests that require legacy BDB wallet (for Bitcoin Core v30)

### DIFF
--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -77,6 +77,9 @@ tasks.register('regTest', Test) {
 
     systemProperty 'regtest', true
     systemProperty 'java.util.logging.config.file', "${project.projectDir}/src/integ/logging.properties"
+    if (project.hasProperty("regTestUseLegacyWallet")) {
+        systemProperty "regTestUseLegacyWallet", project.property("regTestUseLegacyWallet")
+    }
     systemProperties(["omni.test.rpcTestUser"    : rpcTestUser,
                       "omni.test.rpcTestPassword": rpcTestPassword,
     ])

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/bitcoinj/WalletSendSpec.groovy
@@ -19,6 +19,7 @@ import org.bitcoinj.wallet.SendRequest
 import org.bitcoinj.store.MemoryBlockStore
 import org.bitcoinj.utils.BriefLogFormatter
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit
  */
 @Slf4j
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class WalletSendSpec extends BaseRegTestSpec {
     @Shared
     Wallet wallet

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/funding/RegTestFundingSourceSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/funding/RegTestFundingSourceSpec.groovy
@@ -6,11 +6,13 @@ import org.bitcoinj.base.Coin
 import org.bitcoinj.base.Sha256Hash
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 /**
  * Test the fundingSource created by BaseRegTestSpec
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class RegTestFundingSourceSpec extends BaseRegTestSpec {
     @Shared
     RegTestFundingSource source;

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletAppKitRegTestStepwise.groovy
@@ -12,6 +12,8 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoinj.signing.SigningRequest
 import org.consensusj.bitcoinj.signing.TransactionInputData
 import org.consensusj.bitcoinj.signing.Utxo
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -22,6 +24,7 @@ import java.nio.ByteBuffer
  */
 @Slf4j
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class WalletAppKitRegTestStepwise extends BaseRegTestSpec {
     private final hexFormatter = HexFormat.of();
     

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/integ/services/WalletSigningServiceRegTestSpec.groovy
@@ -14,6 +14,8 @@ import org.consensusj.bitcoinj.signing.RawTransactionSigningRequest
 import org.consensusj.bitcoinj.signing.SigningRequest
 import org.consensusj.bitcoinj.signing.TransactionInputData
 import org.consensusj.bitcoinj.signing.Utxo
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import java.nio.ByteBuffer
@@ -23,6 +25,7 @@ import java.nio.ByteOrder
  * RegTest Integration test of WalletSigningService using WalletAppKitService
  */
 @Slf4j
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class WalletSigningServiceRegTestSpec extends BaseRegTestSpec {
     /** The WalletAppKitService that provides UTXOs for testing */
     @Shared WalletAppKitService appKitService

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BTCTestSupportIntegrationSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BTCTestSupportIntegrationSpec.groovy
@@ -2,10 +2,12 @@ package org.consensusj.bitcoin.rpc
 
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Coin
+import spock.lang.IgnoreIf
 
 /**
  * Test Spec for BTCTestSupport.
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BTCTestSupportIntegrationSpec extends BaseRegTestSpec {
 
     def "we can request newly-mined bitcoins"() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinExtendedClientSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinExtendedClientSpec.groovy
@@ -5,6 +5,8 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.jsonrpc.test.FundingSource
 import org.consensusj.bitcoin.jsonrpc.test.RegTestEnvironment
 import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -12,6 +14,7 @@ import spock.lang.Specification
 /**
  * Basic tests of Extended Client
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BitcoinExtendedClientSpec extends Specification {
     @Shared
     BitcoinExtendedClient client
@@ -63,6 +66,7 @@ class BitcoinExtendedClientSpec extends Specification {
     def "Can create a funded address and sign a transaction locally using createSignedTransaction()"() {
         given:
         def fundingAddress = funder.createFundedAddress(10.btc)
+        // Not allowed on Descriptor Wallets
         def key = client.dumpPrivKey(fundingAddress)
         def destinationAddress = client.getNewAddress("destinationAddress")
 

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinJRawTxSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinJRawTxSpec.groovy
@@ -4,6 +4,8 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.Coin
 import org.bitcoinj.core.Transaction
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -16,6 +18,7 @@ import spock.lang.Stepwise
  *
  */
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BitcoinJRawTxSpec extends BaseRegTestSpec {
     final static Coin fundingAmount = 10.btc
     final static Coin sendingAmount = 1.btc
@@ -60,6 +63,7 @@ class BitcoinJRawTxSpec extends BaseRegTestSpec {
         destinationAddress = getNewAddress("destinationAddress")
 
         when: "we get the signing key from the server"
+        // Not supported on Descriptor Wallets
         def key = dumpPrivKey(fundingAddress)
 
         and: "we create an signed bitcoinj transaction, spending from fundingAddress to destinationAddress"

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
@@ -5,6 +5,8 @@ import org.consensusj.bitcoin.json.conversion.HexUtil
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.Coin
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -14,6 +16,7 @@ import java.nio.ByteBuffer
  * Tests of creating and sending raw transactions via RPC
  */
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BitcoinRawTransactionSpec extends BaseRegTestSpec {
     final static Coin fundingAmount = 10.btc
     final static Coin sendingAmount = 1.btc

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinSpec.groovy
@@ -5,7 +5,10 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Coin
 import org.bitcoinj.base.LegacyAddress
 import org.bitcoinj.base.Sha256Hash
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BitcoinSpec extends BaseRegTestSpec {
     static final Coin testAmount = 2.btc
 
@@ -99,6 +102,7 @@ class BitcoinSpec extends BaseRegTestSpec {
         unspent.every { output -> output.address == destinationAddress }
     }
 
+    @Ignore("Not supported on Descriptor Wallets")
     def "We can get the correct private key for an address"() {
         when: "we create a new address and dump it's private key"
         def address = getNewAddress()

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinStepwiseSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/BitcoinStepwiseSpec.groovy
@@ -3,10 +3,12 @@ package org.consensusj.bitcoin.rpc
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Address
 import org.bitcoinj.base.Coin
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BitcoinStepwiseSpec extends BaseRegTestSpec {
     final static Coin sendAmount = 10.btc
     final static Coin extraAmount = 0.1.btc

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/FundingAndBlockChainEnvIntSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/FundingAndBlockChainEnvIntSpec.groovy
@@ -4,6 +4,7 @@ import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.jsonrpc.test.RegTestEnvironment
 import org.consensusj.bitcoin.jsonrpc.test.RegTestFundingSource
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -11,6 +12,7 @@ import spock.lang.Specification
 /**
  * Component-based test (no base test spec, required)
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class FundingAndBlockChainEnvIntSpec extends Specification {
     @Shared BitcoinExtendedClient client
 

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetBlockSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetBlockSpec.groovy
@@ -4,10 +4,12 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.json.pojo.BlockInfo
 import org.bitcoinj.core.Block
 import org.bitcoinj.base.Sha256Hash
+import spock.lang.IgnoreIf
 
 /**
  * Spec for getBlock() and getBlockInfo()
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetBlockSpec extends BaseRegTestSpec {
 
     def "Use RegTest mode to generate a block upon request"() {
@@ -22,13 +24,13 @@ class GetBlockSpec extends BaseRegTestSpec {
         blockCount == startHeight + 1
 
         and: "We have a txid if version > 10"
-        !version10 || version10 && result.size() == 1 && result[0] instanceof Sha256Hash
+        !version10 || version10 && result.size() == 1 && (result[0] instanceof Sha256Hash)
 
         when:
         def block = getBlock(blockCount)
 
         then:
-        block instanceof Block
+        (block instanceof Block)
 
         when:
         def blockInfo = getBlockInfo(block.hash)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/GetTxOutSetInfoSpec.groovy
@@ -4,10 +4,12 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.json.pojo.TxOutSetInfo
 import org.bitcoinj.base.Sha256Hash
 import org.bitcoinj.base.Coin
+import spock.lang.IgnoreIf
 
 /**
  * Test Specification for getTxOutSetInfo
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetTxOutSetInfoSpec extends BaseRegTestSpec {
     def "getTxOutSetInfo passes smoke test"() {
         when:

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/HelpSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/HelpSpec.groovy
@@ -2,10 +2,12 @@ package org.consensusj.bitcoin.rpc
 
 import org.consensusj.bitcoin.json.pojo.MethodHelpEntry
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 
 /**
  * Integration test of {@code help} RPC command
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class HelpSpec extends BaseRegTestSpec {
 
     def "can call help"() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/ImportPrivKeySpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/ImportPrivKeySpec.groovy
@@ -5,6 +5,8 @@ import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.consensusj.bitcoin.json.pojo.AddressInfo
 import org.bitcoinj.base.Address
 import org.bitcoinj.crypto.ECKey
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Stepwise
 
 import static org.bitcoinj.base.BitcoinNetwork.REGTEST
@@ -13,6 +15,7 @@ import static org.bitcoinj.base.BitcoinNetwork.REGTEST
  * Functional test of importPrivKey
  */
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class ImportPrivKeySpec extends BaseRegTestSpec  {
     static final ECKey TEST_PRIVATE_KEY = new ECKey().decompress()
     static final Address TEST_ADDRESS = TEST_PRIVATE_KEY.toAddress(ScriptType.P2PKH, REGTEST)

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/bitcore/GetAddressBalanceSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/bitcore/GetAddressBalanceSpec.groovy
@@ -3,12 +3,14 @@ package org.consensusj.bitcoin.rpc.bitcore
 import org.bitcoinj.base.Coin
 import org.consensusj.bitcoin.json.pojo.bitcore.AddressBalanceInfo
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 /**
  * Test of OmniCore Bitcore address index JSON-RPC method: {@code getaddressbalance}
  * If {@code help} reports address index is not available, these tests are ignored.
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetAddressBalanceSpec extends BaseRegTestSpec {
 
     @Requires({ instance.isAddressIndexEnabled()})

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/bitcore/GetAddressUtxosSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/bitcore/GetAddressUtxosSpec.groovy
@@ -2,12 +2,14 @@ package org.consensusj.bitcoin.rpc.bitcore
 
 import org.consensusj.bitcoin.json.pojo.bitcore.AddressUtxoInfo
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 /**
  * Test of OmniCore Bitcore address index JSON-RPC method: {@code getaddressutxos}
  * If {@code help} reports address index is not available, these tests are ignored.
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetAddressUtxosSpec extends BaseRegTestSpec  {
     @Requires({ instance.isAddressIndexEnabled()})
     def "get utxo info"() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetBlockChainInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetBlockChainInfoSpec.groovy
@@ -3,10 +3,12 @@ package org.consensusj.bitcoin.rpc.blockchain
 import org.bitcoinj.base.Sha256Hash
 import org.consensusj.bitcoin.json.pojo.BlockChainInfo
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 
 /**
  * Functional test of `gettxoutsetinfo` via {@link BitcoinClient#getBlockChainInfo}
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetBlockChainInfoSpec extends BaseRegTestSpec {
     def "response fields are present and pass minimal consistency checks "() {
         when: "we call the RPC"

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/blockchain/GetTxOutSetInfoSpec.groovy
@@ -2,6 +2,7 @@ package org.consensusj.bitcoin.rpc.blockchain
 
 import org.consensusj.bitcoin.test.BaseRegTestSpec
 import org.bitcoinj.base.Coin
+import spock.lang.IgnoreIf
 
 /**
  * Functional test of `gettxoutsetinfo` via {@link BitcoinClient#getTxOutSetInfo}
@@ -11,6 +12,7 @@ import org.bitcoinj.base.Coin
  * https://bitcoin.stackexchange.com/a/38998
  * https://bitcoin.stackexchange.com/a/24684
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class GetTxOutSetInfoSpec extends BaseRegTestSpec
 {
     def "response fields are present and pass minimal consistency checks "() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/BareMultisigSpec.groovy
@@ -10,6 +10,8 @@ import org.bitcoinj.crypto.TransactionSignature
 import org.bitcoinj.script.ScriptBuilder
 import org.bitcoinj.script.Script
 import org.bitcoinj.script.ScriptPattern
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Stepwise
 
@@ -24,6 +26,7 @@ import spock.lang.Stepwise
  * communicate between the "client" and the "server"
  */
 @Stepwise
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class BareMultisigSpec extends TxTestBaseSpec {
 
     private static final ECKey clientKey = new ECKey();

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/OpReturnSpec.groovy
@@ -5,6 +5,8 @@ import org.bitcoinj.core.Transaction
 import org.bitcoinj.script.Script
 import org.bitcoinj.script.ScriptBuilder
 import org.bitcoinj.script.ScriptOpCodes
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import java.util.function.UnaryOperator
@@ -12,6 +14,7 @@ import java.util.function.UnaryOperator
 /**
  *  Create, send, record, and retrieve an OP_RETURN transaction
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class OpReturnSpec extends TxTestBaseSpec {
     @Unroll
     def "create and send a bitcoinj OP_RETURN transaction using #methodName"(UnaryOperator<Transaction> submitMethod, String methodName) {

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/tx/P2PKHSpec.groovy
@@ -3,6 +3,8 @@ package org.consensusj.bitcoin.rpc.tx
 import org.bitcoinj.base.Coin
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.script.ScriptBuilder
+import spock.lang.Ignore
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import java.util.function.UnaryOperator
@@ -10,6 +12,7 @@ import java.util.function.UnaryOperator
 /**
  * Create, send and verify P2PKH transactions via P2P and RPC
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class P2PKHSpec extends TxTestBaseSpec {
 
     @Unroll

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/CreateWalletSpec.groovy
@@ -2,11 +2,13 @@ package org.consensusj.bitcoin.rpc.wallet
 
 import org.consensusj.bitcoin.jsonrpc.test.WalletTestUtil
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 
 /**
  * Test Spec for {@code createwallet}
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class CreateWalletSpec extends BaseRegTestSpec {
 
     @Requires({ instance.clientInstance.getServerVersion() >= 210000})

--- a/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/ListTransactionsSpec.groovy
+++ b/cj-btc-jsonrpc-integ-test/src/integ/groovy/org/consensusj/bitcoin/rpc/wallet/ListTransactionsSpec.groovy
@@ -2,10 +2,12 @@ package org.consensusj.bitcoin.rpc.wallet
 
 import org.consensusj.bitcoin.json.pojo.BitcoinTransactionInfo
 import org.consensusj.bitcoin.test.BaseRegTestSpec
+import spock.lang.IgnoreIf
 
 /**
  * Basic tests of list transactions
  */
+@IgnoreIf({ System.getProperty("regTestUseLegacyWallet") != "true" })
 class ListTransactionsSpec extends BaseRegTestSpec {
 
     def "list transactions (no args)"() {

--- a/cj-btc-jsonrpc-integ-test/src/integ/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
+++ b/cj-btc-jsonrpc-integ-test/src/integ/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
@@ -14,7 +14,9 @@ import org.consensusj.bitcoin.jsonrpc.test.TestServers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,6 +32,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * Java RegTest that mines RegTest coins and sends them to a WalletAppKit
  */
+@EnabledIfSystemProperty(named = "regTestUseLegacyWallet", matches = "true")
 public class WalletAppKitRegTest {
     static final BitcoinNetwork network = BitcoinNetwork.REGTEST;
     static final private TestServers testServers = TestServers.getInstance();

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -51,7 +51,7 @@ public class BitcoinExtendedClient extends BitcoinClient {
     private static final BigInteger NotSoPrivatePrivateInt = new BigInteger(1, Hex.decode("180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19"));
     private static final String RegTestMiningAddressLabel = "RegTestMiningAddress";
     public static final String REGTEST_WALLET_NAME = "consensusj-regtest-wallet";
-    private final boolean useLegacyWallet = true;       // Use legacy wallet even on newer versions
+    private final boolean useLegacyWallet = false;       // Use legacy wallet even on newer versions
     private boolean regTestWalletInitialized = false;
     private /* lazy */ Address regTestMiningAddress;
 

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/test/RegTestFundingSource.java
@@ -139,6 +139,7 @@ public class RegTestFundingSource implements FundingSource {
         Address address = client.getNewAddress();
         requestBitcoin(address, amount);
         ingredients.address = address;
+        // Not supported on Descriptor Wallets
         ingredients.privateKey = client.dumpPrivKey(address);
         ingredients.outPoints = client.listUnspentOutPoints(address);
         return ingredients;

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,9 @@ micronautAppGradlePluginVersion = 4.6.1
 javaMoneyApiVersion = 1.1
 javaMoneyMonetaVersion = 1.4.4
 
+# Disable cj-btc-jsonrpc-integ-test tests that require Legacy BDB Wallet (and don't work on Bitcoin Core v30+)
+# This is a temporary solution, See Issue #223
+regTestUseLegacyWallet = false
+
 rpcTestUser=bitcoinrpc
 rpcTestPassword=pass


### PR DESCRIPTION
These tests are broken by Core v30+,
See Issue #223.

This commit is a work-around until we can migrate the tests to descriptor wallets.