### PR TITLE
jsonrpc-daemon: add UNIX domain socket listener

### DIFF
--- a/consensusj-jsonrpc-daemon/build.gradle
+++ b/consensusj-jsonrpc-daemon/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':consensusj-jsonrpc')
 
     implementation "io.micronaut:micronaut-runtime"
+    implementation "io.netty:netty-transport-native-unix-common"
     implementation "io.micronaut:micronaut-jackson-databind"
     implementation "jakarta.annotation:jakarta.annotation-api"
 

--- a/consensusj-jsonrpc-daemon/src/main/resources/application.yml
+++ b/consensusj-jsonrpc-daemon/src/main/resources/application.yml
@@ -1,3 +1,13 @@
 micronaut:
     application:
-        name: echod
+        name: jsonrpc-echod
+    server:
+        netty:
+            use-native-transport: true
+            listeners:
+                httpListener:
+                    port: 8080
+                unixListener:
+                    # Micronaut can listen/serve over UNIX domain sockets, but it expects HTTP protocol
+                    family: UNIX
+                    path: ${user.home}/jsonrpc-echod-http.socket


### PR DESCRIPTION
Note: Although this listener works on a UNIX domain socket, it still uses the HTTP protocol, so the JSON-RPC requests must be sent with an HTTP POST, etc.