### PR TITLE
build.yml: remove on push, add on workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request, merge_group]
+on: [pull_request, merge_group, workflow_dispatch]
 
 jobs:
   validate_gradle_wrapper:


### PR DESCRIPTION
on `push` is causing too many unnecessary builds, we probably don't need it anymore. Add `workflow_dispatch` so we have the option of manually running the workflow, if needed.