### PR TITLE
gha build build_nix: build devShell before package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,10 +122,10 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Nix Package
-        run: nix build .#consensusj
       - name: Build in Nix development shell
         run: nix develop -c gradle buildCI installDist consensusj-jrpc-echod:nativeTest nativeCompile
+      - name: Build Nix Package
+        run: nix build .#consensusj
 
   all_green:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The package can fail if dependencies aren't updated. In this case it would be nice to know that the devShell build worked correctly.