### PR TITLE
WIP flake.nix: add jrpc-echod to out/bin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
             inherit system;
           };
           mainProgram = "jrpc";
+          echodProgram = "jrpc-echod";
           jdk = pkgs.jdk25;
           graalvm = pkgs.graalvmPackages.graalvm-ce;
           gradle = pkgs.gradle_9.override {
@@ -74,7 +75,7 @@
             preBuild = ''
               export GRAALVM_HOME=${graalvm}
             '';
-            gradleBuildTask = "consensusj-jrpc:nativeCompile";
+            gradleBuildTask = "consensusj-jrpc:nativeCompile consensusj-jrpc-echod:nativeCompile";
 
             gradleFlags = [ "--info --stacktrace" ];
 
@@ -85,6 +86,8 @@
               mkdir -p $out/bin
               cp consensusj-jrpc/build/${mainProgram} $out/bin/${mainProgram}
               wrapProgram $out/bin/${mainProgram}
+              cp consensusj-jrpc-echod/build/${echodProgram} $out/bin/${echodProgram}
+              wrapProgram $out/bin/${echodProgram}
             '';
           });
         in


### PR DESCRIPTION
There is currently at least one issue to be solved:

* nativeCompile with Gradle Native Plugin accesses the Graal Metadata repository via HTTP and this doesn't work in the Nix sandbox and is not cached by the mitm mechanism. We need to get local metadata somehow.