### PR TITLE
consensusj-jsonrpc module-info: export internal to Jackson databind

### DIFF
--- a/consensusj-jsonrpc/src/main/java/module-info.java
+++ b/consensusj-jsonrpc/src/main/java/module-info.java
@@ -13,4 +13,5 @@ module org.consensusj.jsonrpc {
 
     exports org.consensusj.jsonrpc;
     exports org.consensusj.jsonrpc.introspection;
+    exports org.consensusj.jsonrpc.internal to com.fasterxml.jackson.databind;
 }


### PR DESCRIPTION
This is necessary when running the `jrpc` via the `installDist` script now that module-path is being used.