### PR TITLE
consensusj-jrpc-echod/build.gradle: set applicationName properly

### DIFF
--- a/consensusj-jrpc-echod/build.gradle
+++ b/consensusj-jrpc-echod/build.gradle
@@ -17,10 +17,15 @@ micronaut {
     }
 }
 
+application {
+    mainClass.set("org.consensusj.jsonrpc.daemon.Application")
+    applicationName = 'jrpc-echod'
+}
+
 graalvmNative {
     binaries {
         main {
-            imageName = 'jrpc-echod'
+            imageName = application.applicationName
             buildArgs.add('-H:+UnlockExperimentalVMOptions')
             buildArgs.add('-H:-CheckToolchain')
             // SharedArenaSupport seems to require GraalVM 25
@@ -47,10 +52,6 @@ dependencies {
     runtimeOnly "ch.qos.logback:logback-classic"
 
     // Tests are automatically configured by `micronaut.testRuntime("junit5")` above
-}
-
-application {
-    mainClass.set("org.consensusj.jsonrpc.daemon.Application")
 }
 
 dockerBuild {


### PR DESCRIPTION
Set application.applicationName = 'jrpc-echod', so the correct app name is used for the output of the `installDist` task.