### PR TITLE
javadocAll use separate Gradle task and GHA job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,33 @@ jobs:
         name: artifacts-${{ matrix.os }}-${{ matrix.java }}
         path: build/artifacts
 
+  javadoc_all:
+    needs: build_gradle
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        java: ['25']
+        distribution: ['temurin']
+      fail-fast: false
+    name: JavadocAll ${{ matrix.os }} JDK ${{ matrix.java }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v6
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java }}
+          cache: 'gradle'
+      - name: Build with Gradle
+        run: ./gradlew javadocAll --scan --info --stacktrace
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: artifacts-${{ matrix.os }}-${{ matrix.java }}
+          path: build/docs/javadoc
+
   graalvm:
     needs: validate_gradle_wrapper
     runs-on: ${{ matrix.os }}
@@ -129,6 +156,6 @@ jobs:
 
   all_green:
     runs-on: ubuntu-24.04
-    needs: [validate_gradle_wrapper, build_gradle, graalvm, regtest, build_nix]
+    needs: [validate_gradle_wrapper, build_gradle, graalvm, regtest, build_nix, javadoc_all]
     steps:
       - run: echo "All upstream jobs passed"

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ tasks.named('check') {
 
 build.dependsOn subprojects.build
 
-tasks.register('buildCI') { dependsOn build, javadocAll /*, asciidoctor */ }
+tasks.register('buildCI') { dependsOn build /*, asciidoctor */ }
 
 tasks.named('installDist').configure {
     destinationDir = layout.buildDirectory.dir('artifacts').get().getAsFile()

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -4,8 +4,6 @@ ext.javadocSpec = {
     options.addBooleanOption 'linksource', true             // include link to HTML source file
     modularity.inferModulePath = false                      // Disable modular JavaDoc for now
     exclude("module-info.java")
-
-    options.links(javaDocLinks() as String[])
 }
 
 allprojects {
@@ -17,6 +15,7 @@ tasks.register('javadocAll', Javadoc) {
     classpath = files(subprojects.collect { project -> project.sourceSets.main.compileClasspath })
 }
 javadocAll javadocSpec << {
+    options.links(javaDocLinks() as String[])
     // TODO: Convert this back to HTML
     // options.overview = "doc/javadoc-overview.adoc"
     // inputs.file(options.overview)

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -5,17 +5,7 @@ ext.javadocSpec = {
     modularity.inferModulePath = false                      // Disable modular JavaDoc for now
     exclude("module-info.java")
 
-    List<CharSequence> javaDocLinks = [
-            "https://docs.oracle.com/en/java/javase/17/docs/api",
-            "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jacksonVersion}",
-            "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jacksonVersion}"
-    ]
-
-    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("rc") && !bitcoinjVersion.contains("SNAPSHOT") && !bitcoinjVersion.contains("0.17.1")) {
-        javaDocLinks << "https://bitcoinj.org/javadoc/${bitcoinjVersion}/"
-    }
-
-    options.links(javaDocLinks as String[])
+    options.links(javaDocLinks() as String[])
 }
 
 allprojects {
@@ -33,4 +23,18 @@ javadocAll javadocSpec << {
 }
 javadocAll.doLast {
     logger.info "Consolidated JavaDoc generated at <file://${javadocAll.destinationDir}/index.html>"
+}
+
+// Return links to external Javadocs
+List<CharSequence> javaDocLinks() {
+    List<CharSequence> javaDocLinks = [
+            "https://docs.oracle.com/en/java/javase/17/docs/api",
+            "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jacksonVersion}",
+            "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jacksonVersion}"
+    ]
+
+    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("rc") && !bitcoinjVersion.contains("SNAPSHOT") && !bitcoinjVersion.contains("0.17.1")) {
+        javaDocLinks << "https://bitcoinj.org/javadoc/${bitcoinjVersion}/"
+    }
+    return Collections.unmodifiableList(javaDocLinks)
 }


### PR DESCRIPTION
This should reduce network access to verify the links to one task/job. This will allow must build to not have the network access at all and for GHA reduce the network access to a single task/job.