### PR TITLE
Reenable WalletAppKitRegTest, if dumpPrivKeyAvailable then reenable BareMultiSigSpec, OpReturnSpec, P2PKHSpec

### DIFF
--- a/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
+++ b/cj-btc-jsonrpc-gvy/src/main/groovy/org/consensusj/bitcoin/jsonrpc/groovy/test/JTransactionTestSupport.groovy
@@ -79,7 +79,7 @@ trait JTransactionTestSupport implements BTCTestSupport {
     }
 
     Transaction submitRPC(Transaction tx) {
-        Sha256Hash txid = client.sendRawTransaction(tx, null, Coin.FIFTY_COINS)
+        Sha256Hash txid = client.sendRawTransaction(tx)
         client.generateBlocks(1)
         Transaction sentTx = client.getRawTransaction(txid)
         RawTransactionInfo txinfo = client.getRawTransactionInfo(txid)

--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -55,6 +55,7 @@ testing {
                         }
                         systemProperty 'regtest', true
                         systemProperty 'java.util.logging.config.file', "${project.projectDir}/src/regTest/logging.properties"
+                        systemProperty 'dumpPrivKeyAvailable', findProperty('dumpPrivKeyAvailable') ?: 'true'
                         if (project.hasProperty("regTestUseLegacyWallet")) {
                             systemProperty "regTestUseLegacyWallet", project.property("regTestUseLegacyWallet")
                         }

--- a/cj-btc-jsonrpc-integ-test/src/regTest/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
+++ b/cj-btc-jsonrpc-integ-test/src/regTest/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeoutException;
 /**
  * Java RegTest that mines RegTest coins and sends them to a WalletAppKit
  */
-@EnabledIfSystemProperty(named = "regTestUseLegacyWallet", matches = "true")
 public class WalletAppKitRegTest {
     static final BitcoinNetwork network = BitcoinNetwork.REGTEST;
     static final private TestServers testServers = TestServers.getInstance();

--- a/cj-btc-jsonrpc-integ-test/src/regTest/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
+++ b/cj-btc-jsonrpc-integ-test/src/regTest/java/org/consensusj/bitcoin/integ/java/WalletAppKitRegTest.java
@@ -17,21 +17,16 @@ package org.consensusj.bitcoin.integ.java;
 
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
-import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient;
 import org.consensusj.bitcoin.jsonrpc.RpcURI;
 import org.consensusj.bitcoin.jsonrpc.test.TestServers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,9 +73,9 @@ public class WalletAppKitRegTest {
 
         // Listen for the first coins-received transaction
         var transactionFuture = new CompletableFuture<Transaction>();
-        kit.wallet().addCoinsReceivedEventListener((Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) -> {
-            transactionFuture.complete(tx);
-        });
+        kit.wallet().addCoinsReceivedEventListener((Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) ->
+            transactionFuture.complete(tx)
+        );
 
         // Prepare the amount to send and destination address
         var amount = Coin.CENT;

--- a/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
+++ b/cj-btc-jsonrpc/src/main/java/org/consensusj/bitcoin/jsonrpc/BitcoinExtendedClient.java
@@ -66,7 +66,6 @@ public class BitcoinExtendedClient extends BitcoinClient {
     private static final BigInteger NotSoPrivatePrivateInt = new BigInteger(1, Hex.decode("180cb41c7c600be951b5d3d0a7334acc7506173875834f7a6c4c786a28fcbb19"));
     private static final String RegTestMiningAddressLabel = "RegTestMiningAddress";
     public static final String REGTEST_WALLET_NAME = "consensusj-regtest-wallet";
-    private final boolean useLegacyWallet = false;       // Use legacy wallet even on newer versions
     private boolean regTestWalletInitialized = false;
     private /* lazy */ Address regTestMiningAddress;
 
@@ -139,11 +138,10 @@ public class BitcoinExtendedClient extends BitcoinClient {
                 if (addressInfo.getIsmine() && !addressInfo.getIswatchonly() && addressInfo.getSolvable()) {
                     log.warn("Address with label {} is present in server-side wallet", RegTestMiningAddressLabel);
                     regTestMiningAddress = address;
-                } else if (getServerVersion() >= BITCOIN_CORE_VERSION_DESC_DEFAULT && !useLegacyWallet) {
+                } else if (getServerVersion() >= BITCOIN_CORE_VERSION_DESC_DEFAULT) {
                     // Import known private key as descriptor wallet and rescan the blockchain for any transactions from
                     // previous test runs, rescan shouldn't take too long on a typical RegTest chain
-                    // TODO: This pretty much works, but we have regTests that require LegacyWallet that need to be
-                    // made optional/conditional. There is also an issue with the ` confidence.depthInBlocks == 1` condition
+                    // TODO: This pretty much works, but here is (was) also an issue with the ` confidence.depthInBlocks == 1` condition
                     // in WalletSendSpec. We can enable this code when those are fixed.
                     String wif = notSoPrivatePrivateKey.getPrivateKeyAsWiF(BitcoinNetwork.REGTEST);
                     String descriptor = String.format("pkh(%s)#uv04hy66", wif);     // TODO: Fix hard-coded checksum
@@ -194,8 +192,8 @@ public class BitcoinExtendedClient extends BitcoinClient {
      */
     private void createRegTestWallet(int bitcoinCoreVersion, String name) throws JsonRpcStatusException, IOException {
         LoadWalletResult result = (bitcoinCoreVersion >= BITCOIN_CORE_VERSION_DESC_DEFAULT)
-                    // Use newer parameters if available, for older Bitcoin Core use older params
-                    ? createWallet(name, false, false, null, null, !useLegacyWallet, null, null)
+                    // Use newer parameters and create descriptor wallet (if supported), for older Bitcoin Core use older params
+                    ? createWallet(name, false, false, null, null, true, null, null)
                     : createWallet(name, false, false, null, null);
 
         if (result.getWarning() == null || result.getWarning().isEmpty()) {


### PR DESCRIPTION
Three significant improvements:

* `WalletAppKitRegTest`: reenable. This Java-based test of WalletAppKit was fixed by recent changes and works with both Bitcoin Core v30.2 and v20.1.
* `JTransactionTestSupport`: Use v20.1 compatible sendRawTransaction. This allows `BareMultiSigSpec`, `OpReturnSpec`, `P2PKHSpec` to run on v20.1
* Set `dumpPrivKeyAvailable` system property so that setting `dumpPrivKeyAvailable` in `gradle.properties` actually runs the conditional tests when this property is set.

There is also some relatively minor code cleanup.

After these changes, all appropriately enabled tests run on both v30.2 and v20.1.