### PR TITLE
test-run-regtest.sh: use -fallbackfee instead of -paytxfee

### DIFF
--- a/test-run-regtest.sh
+++ b/test-run-regtest.sh
@@ -26,7 +26,7 @@ $BITCOIND -regtest -datadir=$DATADIR \
   -addresstype=legacy \
   -peerbloomfilters \
   -deprecatedrpc=create_bdb \
-  -paytxfee=0.0001 -minrelaytxfee=0.00001 \
+  -fallbackfee=0.0001 -minrelaytxfee=0.00001 \
   -limitancestorcount=750 -limitdescendantcount=750 > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!


### PR DESCRIPTION
This script is used to run regTest on GitHub Actions and this change is necessary because Bitcoin Core v31.0 removes `-paytxfee` which has been deprecated. `-fallbackfee` does what we need for our regTests.