### PR TITLE
build.gradle: remove `project(':')` from `subprojects` reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,7 @@ apply from: 'gradle/maven-publish.gradle'
 apply from: 'gradle/licenseCheck.gradle'
 
 dependencies {
-    testReportAggregation project(':').subprojects
+    testReportAggregation subprojects
 }
 
 tasks.named('check') {


### PR DESCRIPTION
This is necessary to support Gradle 9.5.0, but works on earlier versions (tested on 9.4.1)