### PR TITLE
gradle.properties: set consensusjVersion 0.7.0-DEV

### DIFF
--- a/cj-bitcoinj-dsl-gvy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/cj-bitcoinj-dsl-gvy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,4 +1,4 @@
 moduleName=ConsensusJ Groovy extensions for bitcoinj
-moduleVersion=0.7.0-SNAPSHOT
+moduleVersion=0.7.0-DEV
 extensionClasses=org.consensusj.bitcoinj.dsl.groovy.categories.CoinCategory,org.consensusj.bitcoinj.dsl.groovy.categories.NumberCategory
 staticExtensionClasses=org.consensusj.bitcoinj.dsl.groovy.categories.StaticECKeyExtension

--- a/doc/release-process.adoc
+++ b/doc/release-process.adoc
@@ -9,6 +9,7 @@ NOTE:: Procedure needs steps to update `nix-deps.json`.
 . Update `CHANGELOG.adoc`
 . Set versions
 .. `gradle.properties`
+.. `flake.nix`
 .. `cj-bitcoinj-dsl-gvy` `ExtensionModule`
 .. `README.adoc` (check/set bitcoinj version variable, too)
 . Update `README.adoc` and other documentation as necessary
@@ -33,7 +34,7 @@ NOTE:: Procedure needs steps to update `nix-deps.json`.
 
 == After release
 
-. Set versions back to -SNAPSHOT
+. Set versions back to -DEV
 .. `gradle.properties`
 .. cj-bitcoinj-dsl-gvy `ExtensionModule`
 .. `CHANGELOG.adoc`

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
           };
           self2 = pkgs.stdenv.mkDerivation (_finalAttrs: {
             pname = "consensusj-tools";
-            version = "0.7.0-SNAPSHOT";
+            version = "0.7.0-DEV";
             meta = {
               inherit mainProgram;
             };

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
-consensusjVersion = 0.7.0-SNAPSHOT
+# We use -DEV instead of -SNAPSHOT for unreleased/untagged versions.
+# Gradle builds for the `publish` target are non-reproducible/non-deterministic when
+# the version contains `-SNAPSHOT`. (`-SNAPSHOT` is treated as special case and output jars
+# are given a filename with a timestamped version`.)
+consensusjVersion = 0.7.0-DEV
 
 bitcoinjVersion = 0.17.1
 rxJavaVersion = 3.1.12


### PR DESCRIPTION
Ue -DEV instead of -SNAPSHOT for unreleased/untagged versions, because Gradle builds for the `publish` target are non-reproducible/non-deterministic when the version contains `-SNAPSHOT`.