### PR TITLE
flake.nix: set nixpkgs to nixos-26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782461078,
-        "narHash": "sha256-JXd3OsX9+pAeJQBuc5R0YGF+8Y8PcIHPFtIhggVLz+U=",
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0aa63ff894fac19861504726aa78972294cf9133",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-26.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ConsensusJ devShell and consensusj-tools (jrpc for now) package";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-26.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   };
 
   outputs = { self, nixpkgs }:


### PR DESCRIPTION
nixos-26.05 is the correct "stable" branch to use
for release 26.05, having received the most testing and having the most extensive binary cache.

See: https://nix.dev/concepts/faq.html#stable