### PR TITLE
add cj-btc-rocksdb: RocksDB module for blockchain database

### DIFF
--- a/cj-btc-rocksdb/build.gradle
+++ b/cj-btc-rocksdb/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * RocksDB-based Bitcoin blockchain database (reader and writer).
+ */
+plugins {
+    id 'java-library'
+}
+
+ext.moduleName = 'org.consensusj.bitcoin.rocksdb'
+
+tasks.withType(JavaCompile).configureEach {
+    // This module uses records, so it requires a release level >= 16.
+    // (slf4j, JUnit Jupiter and Spock test dependencies are supplied by the root build.gradle.)
+    options.release = 21
+}
+
+dependencies {
+    // BitcoinJ for Bitcoin types (Address, Sha256Hash, Block, etc.)
+    api "org.bitcoinj:bitcoinj-core:${bitcoinjVersion}"
+
+    // RocksDB for the database backend
+    api "org.rocksdb:rocksdbjni:${rocksdbVersion}"
+}
+
+jar {
+    inputs.property("moduleName", moduleName)
+    manifest {
+        attributes  'Implementation-Title': 'ConsensusJ Bitcoin RocksDB Database',
+                'Automatic-Module-Name': moduleName,
+                'Implementation-Version': archiveVersion.get()
+    }
+}
+
+test {
+    // RocksDB loads a native library; grant native access to silence JDK warnings.
+    jvmArgs '--enable-native-access=ALL-UNNAMED'
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/AbstractRocksDbBlockchainDatabase.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/AbstractRocksDbBlockchainDatabase.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.ProtocolException;
+import org.consensusj.bitcoin.rocksdb.reader.BlockchainDatabase;
+import org.consensusj.bitcoin.rocksdb.schema.BlockchainSchema;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Shared read implementation for {@link BlockchainDatabase}.
+ *
+ * Opens the RocksDB database, maps the column families from {@link BlockchainSchema} and builds
+ * an in-memory height index by walking the header chain back from the tip. Subclasses just pick
+ * the open mode (read-only reader vs. read-write writer).
+ */
+public abstract class AbstractRocksDbBlockchainDatabase implements BlockchainDatabase {
+    private static final Logger log = LoggerFactory.getLogger(AbstractRocksDbBlockchainDatabase.class);
+
+    protected final RocksDB db;
+    protected final List<ColumnFamilyHandle> columnFamilyHandles;
+    protected final ColumnFamilyHandle fundingCF;
+    protected final ColumnFamilyHandle spendingCF;
+    protected final ColumnFamilyHandle txidCF;
+    protected final ColumnFamilyHandle headersCF;
+    protected final ColumnFamilyHandle configCF;
+    protected final NetworkParameters networkParameters;
+
+    // headers are not keyed by height on disk, so we keep this index in memory
+    protected final Map<Integer, Block> headersByHeight = new HashMap<>();
+
+    private final DBOptions options;
+
+    protected AbstractRocksDbBlockchainDatabase(Path dbPath, NetworkParameters networkParameters, boolean readOnly) throws RocksDBException {
+        if (networkParameters == null) {
+            throw new IllegalArgumentException("networkParameters cannot be null");
+        }
+        this.networkParameters = networkParameters;
+        this.columnFamilyHandles = new ArrayList<>();
+
+        RocksDB.loadLibrary();
+
+        List<ColumnFamilyDescriptor> columnFamilyDescriptors = new ArrayList<>();
+        for (String cfName : BlockchainSchema.ColumnFamilies.ALL) {
+            columnFamilyDescriptors.add(new ColumnFamilyDescriptor(cfName.getBytes()));
+        }
+
+        this.options = new DBOptions()
+                .setCreateIfMissing(false)
+                .setCreateMissingColumnFamilies(false);
+
+        try {
+            this.db = readOnly
+                    ? RocksDB.openReadOnly(options, dbPath.toString(), columnFamilyDescriptors, columnFamilyHandles)
+                    : RocksDB.open(options, dbPath.toString(), columnFamilyDescriptors, columnFamilyHandles);
+
+            this.fundingCF = findColumnFamily(BlockchainSchema.ColumnFamilies.FUNDING);
+            this.spendingCF = findColumnFamily(BlockchainSchema.ColumnFamilies.SPENDING);
+            this.txidCF = findColumnFamily(BlockchainSchema.ColumnFamilies.TXID);
+            this.headersCF = findColumnFamily(BlockchainSchema.ColumnFamilies.HEADERS);
+            this.configCF = findColumnFamily(BlockchainSchema.ColumnFamilies.CONFIG);
+
+            log.info("Opened blockchain database at {} ({}) with {} column families",
+                    dbPath, readOnly ? "read-only" : "read-write", columnFamilyHandles.size());
+
+            loadHeaders();
+            log.info("Loaded {} block headers into memory", headersByHeight.size());
+        } catch (RocksDBException e) {
+            // don't leak the native handles if the open blew up half way through
+            columnFamilyHandles.forEach(ColumnFamilyHandle::close);
+            options.close();
+            throw e;
+        }
+    }
+
+    private ColumnFamilyHandle findColumnFamily(String name) {
+        for (int i = 0; i < BlockchainSchema.ColumnFamilies.ALL.length; i++) {
+            if (BlockchainSchema.ColumnFamilies.ALL[i].equals(name)) {
+                return columnFamilyHandles.get(i);
+            }
+        }
+        throw new IllegalStateException("Column family not found: " + name);
+    }
+
+    private void loadHeaders() throws RocksDBException {
+        Map<Sha256Hash, Block> headerMap = new HashMap<>();
+
+        try (RocksIterator iterator = db.newIterator(headersCF)) {
+            iterator.seekToFirst();
+            while (iterator.isValid()) {
+                byte[] key = iterator.key();
+
+                if (key.length == 1 && key[0] == 'T') {        // the chain-tip marker, not a header
+                    iterator.next();
+                    continue;
+                }
+
+                if (key.length == BlockchainSchema.HEADER_SIZE) {
+                    try {
+                        Block block = networkParameters.getDefaultSerializer().makeBlock(ByteBuffer.wrap(key));
+                        headerMap.put(block.getHash(), block);
+                    } catch (ProtocolException e) {
+                        log.warn("Failed to deserialize header, skipping: {}", e.getMessage());
+                    }
+                } else {
+                    log.warn("Skipping header-CF key with unexpected length: {} bytes", key.length);
+                }
+                iterator.next();
+            }
+        }
+
+        Optional<Sha256Hash> tipHashOpt = getChainTipHash();
+        if (tipHashOpt.isEmpty()) {
+            log.warn("No chain tip found, cannot build height index");
+            return;
+        }
+
+        // walk back from the tip following prevBlockHash, so the list comes out tip-first
+        List<Sha256Hash> chain = new ArrayList<>();
+        Sha256Hash currentHash = tipHashOpt.get();
+        while (headerMap.containsKey(currentHash)) {
+            Block header = headerMap.get(currentHash);
+            chain.add(currentHash);
+            currentHash = header.getPrevBlockHash();
+        }
+
+        int tipHeight = chain.size() - 1;
+        for (int i = 0; i < chain.size(); i++) {
+            headersByHeight.put(tipHeight - i, headerMap.get(chain.get(i)));
+        }
+
+        log.debug("Built chain with {} headers, tip at height {}", headersByHeight.size(), tipHeight);
+    }
+
+    @Override
+    public Optional<Integer> getChainTipHeight() {
+        if (headersByHeight.isEmpty()) {
+            return Optional.empty();
+        }
+        return headersByHeight.keySet().stream().max(Integer::compareTo);
+    }
+
+    @Override
+    public Optional<Sha256Hash> getChainTipHash() {
+        try {
+            byte[] tipHash = db.get(headersCF, BlockchainSchema.Keys.CHAIN_TIP);
+            if (tipHash == null) {
+                return Optional.empty();
+            }
+            // stored in internal byte oder, Sha256Hash wants it reversed
+            return Optional.of(Sha256Hash.wrap(reverseBytes(tipHash)));
+        } catch (RocksDBException e) {
+            log.error("Error getting chain tip hash", e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<Block> getBlockHeader(int height) {
+        return Optional.ofNullable(headersByHeight.get(height));
+    }
+
+    @Override
+    public Optional<Integer> getTransactionHeight(Sha256Hash txid) {
+        try {
+            byte[] heightBytes = db.get(txidCF, BlockchainSchema.txidKey(txid));
+            if (heightBytes == null) {
+                return Optional.empty();
+            }
+            return Optional.of(BlockchainSchema.decodeHeight(heightBytes));
+        } catch (RocksDBException e) {
+            log.error("Error getting transaction height for {}", txid, e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Integer> getFundingHeights(byte[] scriptHashPrefix) {
+        if (scriptHashPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Script hash prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+
+        List<Integer> heights = new ArrayList<>();
+        try (RocksIterator iterator = db.newIterator(fundingCF)) {
+            iterator.seek(scriptHashPrefix);
+            while (iterator.isValid()) {
+                byte[] key = iterator.key();
+                if (!startsWithPrefix(key, scriptHashPrefix)) {
+                    break;
+                }
+                heights.add(BlockchainSchema.extractFundingHeight(key));
+                iterator.next();
+            }
+        }
+        return heights;
+    }
+
+    @Override
+    public List<Integer> getSpendingHeights(Sha256Hash txid, int vout) {
+        byte[] txidPrefix = BlockchainSchema.txidKey(txid);
+        List<Integer> heights = new ArrayList<>();
+
+        try (RocksIterator iterator = db.newIterator(spendingCF)) {
+            // seek to the first key for this txid+vout, then read until the prefix stops matching
+            byte[] prefixKey = BlockchainSchema.spendingKey(txidPrefix, (short) vout, 0);
+            iterator.seek(Arrays.copyOfRange(prefixKey, 0, BlockchainSchema.PREFIX_LENGTH + 2));
+
+            while (iterator.isValid()) {
+                byte[] key = iterator.key();
+                byte[] keyTxidPrefix = BlockchainSchema.extractTxidPrefix(key);
+                short keyVout = BlockchainSchema.extractVout(key);
+                if (!Arrays.equals(keyTxidPrefix, txidPrefix) || keyVout != vout) {
+                    break;
+                }
+                heights.add(BlockchainSchema.extractSpendingHeight(key));
+                iterator.next();
+            }
+        }
+        return heights;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return db != null && db.isOwningHandle();
+    }
+
+    @Override
+    public DatabaseStats getStats() {
+        long fundingKeys = estimateNumKeys(fundingCF);
+        long spendingKeys = estimateNumKeys(spendingCF);
+        long txidKeys = estimateNumKeys(txidCF);
+        long headerKeys = estimateNumKeys(headersCF);
+        long totalSize = 0;
+
+        try {
+            totalSize = Long.parseLong(db.getProperty("rocksdb.total-sst-files-size"));
+        } catch (RocksDBException e) {
+            log.warn("Could not get database size", e);
+        }
+
+        return new DatabaseStats(fundingKeys, spendingKeys, txidKeys, headerKeys, totalSize);
+    }
+
+    @Override
+    public void close() {
+        log.info("Closing blockchain database");
+        columnFamilyHandles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        options.close();
+    }
+
+    private long estimateNumKeys(ColumnFamilyHandle cf) {
+        try {
+            return Long.parseLong(db.getProperty(cf, "rocksdb.estimate-num-keys"));
+        } catch (RocksDBException e) {
+            log.warn("Could not estimate number of keys", e);
+            return 0;
+        }
+    }
+
+    private static boolean startsWithPrefix(byte[] key, byte[] prefix) {
+        if (key.length < prefix.length) {
+            return false;
+        }
+        for (int i = 0; i < prefix.length; i++) {
+            if (key[i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // reversed copy, for converting between the db's internal hash order and bitcoinj's display order
+    protected static byte[] reverseBytes(byte[] bytes) {
+        byte[] reversed = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            reversed[i] = bytes[bytes.length - 1 - i];
+        }
+        return reversed;
+    }
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/reader/BlockchainDatabase.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/reader/BlockchainDatabase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.reader;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Block;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only interface to a Bitcoin blockchain RocksDB database. Lets you query by script hash
+ * (address history), transaction id and block height.
+ *
+ * @see org.consensusj.bitcoin.rocksdb.schema.BlockchainSchema
+ */
+public interface BlockchainDatabase extends Closeable {
+
+    Optional<Integer> getChainTipHeight();
+
+    Optional<Sha256Hash> getChainTipHash();
+
+    Optional<Block> getBlockHeader(int height);
+
+    Optional<Integer> getTransactionHeight(Sha256Hash txid);
+
+    /** @param scriptHashPrefix first 8 bytes of SHA256(script) */
+    List<Integer> getFundingHeights(byte[] scriptHashPrefix);
+
+    List<Integer> getSpendingHeights(Sha256Hash txid, int vout);
+
+    boolean isOpen();
+
+    DatabaseStats getStats();
+
+    record DatabaseStats(
+        long fundingKeys,
+        long spendingKeys,
+        long txidKeys,
+        long headerKeys,
+        long totalSize
+    ) {}
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/reader/RocksDbBlockchainDatabase.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/reader/RocksDbBlockchainDatabase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.reader;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.consensusj.bitcoin.rocksdb.AbstractRocksDbBlockchainDatabase;
+import org.rocksdb.RocksDBException;
+
+import java.nio.file.Path;
+
+/**
+ * Read-only view of a blockchain RocksDB database. All the actual work lives in
+ * {@link AbstractRocksDbBlockchainDatabase}; this just opens it read-only.
+ */
+public class RocksDbBlockchainDatabase extends AbstractRocksDbBlockchainDatabase {
+
+    public RocksDbBlockchainDatabase(Path dbPath, NetworkParameters networkParameters) throws RocksDBException {
+        super(dbPath, networkParameters, true);
+    }
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/schema/BlockchainSchema.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/schema/BlockchainSchema.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.schema;
+
+import org.bitcoinj.base.Sha256Hash;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * Column families and key formats for the blockchain RocksDB database.
+ *
+ * The layout is inspired by electrs - most indexes are key-only (empty value) to save space - but
+ * the encoding is our own and is not byte-for-byte compatible with electrs.
+ *
+ * One gotcha: headers aren't keyed by height. The 80-byte serialized header is itself the key, so
+ * to look one up by height you have to load every header and rebuild the chain from the tip.
+ *
+ * @see <a href="https://github.com/romanz/electrs/blob/master/doc/schema.md">Electrs Schema Documentation</a>
+ */
+public class BlockchainSchema {
+
+    public static final class ColumnFamilies {
+        public static final String FUNDING = "funding";    // script hash prefix -> height
+        public static final String SPENDING = "spending";  // outpoint prefix -> spending height
+        public static final String TXID = "txid";          // txid prefix -> confirmed height
+        public static final String HEADERS = "headers";    // 80-byte header keys
+        public static final String CONFIG = "config";
+        public static final String DEFAULT = "default";    // required by RocksDB
+
+        public static final String[] ALL = {
+            DEFAULT, FUNDING, SPENDING, TXID, HEADERS, CONFIG
+        };
+    }
+
+    public static final class Keys {
+        public static final byte[] CHAIN_TIP = new byte[] { 'T' };
+        public static final byte[] CONFIG = new byte[] { 'C' };
+    }
+
+    /** 8-byte prefixes are used for both script hashes and txids. */
+    public static final int PREFIX_LENGTH = 8;
+
+    public static final int HEADER_SIZE = 80;
+
+    /** funding key = SHA256(script)[:8] + height, 12 bytes total. */
+    public static byte[] fundingKey(byte[] scriptHashPrefix, int height) {
+        if (scriptHashPrefix.length != PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Script hash prefix must be " + PREFIX_LENGTH + " bytes");
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(PREFIX_LENGTH + 4);
+        buffer.put(scriptHashPrefix);
+        buffer.putInt(height);
+        return buffer.array();
+    }
+
+    /** spending key = txid[:8] + vout + height, 14 bytes total. */
+    public static byte[] spendingKey(byte[] txidPrefix, short vout, int height) {
+        if (txidPrefix.length != PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Txid prefix must be " + PREFIX_LENGTH + " bytes");
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(PREFIX_LENGTH + 2 + 4);
+        buffer.put(txidPrefix);
+        buffer.putShort(vout);
+        buffer.putInt(height);
+        return buffer.array();
+    }
+
+    public static byte[] txidKey(Sha256Hash txid) {
+        return Arrays.copyOfRange(txid.getBytes(), 0, PREFIX_LENGTH);
+    }
+
+    public static byte[] txidKey(byte[] txidBytes) {
+        return Arrays.copyOfRange(txidBytes, 0, PREFIX_LENGTH);
+    }
+
+    public static int decodeHeight(byte[] value) {
+        if (value.length != 4) {
+            throw new IllegalArgumentException("Height value must be 4 bytes, got " + value.length);
+        }
+        return ByteBuffer.wrap(value).getInt();
+    }
+
+    public static byte[] encodeHeight(int height) {
+        return ByteBuffer.allocate(4).putInt(height).array();
+    }
+
+    public static byte[] extractScriptHashPrefix(byte[] fundingKey) {
+        return Arrays.copyOfRange(fundingKey, 0, PREFIX_LENGTH);
+    }
+
+    public static int extractFundingHeight(byte[] fundingKey) {
+        return ByteBuffer.wrap(fundingKey, PREFIX_LENGTH, 4).getInt();
+    }
+
+    public static byte[] extractTxidPrefix(byte[] spendingKey) {
+        return Arrays.copyOfRange(spendingKey, 0, PREFIX_LENGTH);
+    }
+
+    public static short extractVout(byte[] spendingKey) {
+        return ByteBuffer.wrap(spendingKey, PREFIX_LENGTH, 2).getShort();
+    }
+
+    public static int extractSpendingHeight(byte[] spendingKey) {
+        return ByteBuffer.wrap(spendingKey, PREFIX_LENGTH + 2, 4).getInt();
+    }
+
+    /** Empty value used by the key-only indexes. */
+    public static byte[] emptyValue() {
+        return new byte[0];
+    }
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/writer/RocksDbWritableBlockchainDatabase.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/writer/RocksDbWritableBlockchainDatabase.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.writer;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.NetworkParameters;
+import org.consensusj.bitcoin.rocksdb.AbstractRocksDbBlockchainDatabase;
+import org.consensusj.bitcoin.rocksdb.schema.BlockchainSchema;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read-write version of the blockchain database. Adds the put/delete operations on top of
+ * {@link AbstractRocksDbBlockchainDatabase}. Writes are batched and only hit disk on {@link #flush()},
+ * so remember to flush (close() will do it for you if you forget).
+ */
+public class RocksDbWritableBlockchainDatabase extends AbstractRocksDbBlockchainDatabase implements WritableBlockchainDatabase {
+    private static final Logger log = LoggerFactory.getLogger(RocksDbWritableBlockchainDatabase.class);
+
+    private final WriteBatch writeBatch;
+    private final WriteOptions writeOptions;
+
+    public RocksDbWritableBlockchainDatabase(Path dbPath, NetworkParameters networkParameters) throws RocksDBException {
+        super(dbPath, networkParameters, false);
+        this.writeBatch = new WriteBatch();
+        this.writeOptions = new WriteOptions();
+    }
+
+    /**
+     * Creates the database (with all the column families) and reopens it read-write.
+     */
+    public static RocksDbWritableBlockchainDatabase create(Path dbPath, NetworkParameters networkParameters) throws RocksDBException {
+        RocksDB.loadLibrary();
+
+        List<ColumnFamilyDescriptor> columnFamilyDescriptors = new ArrayList<>();
+        for (String cfName : BlockchainSchema.ColumnFamilies.ALL) {
+            columnFamilyDescriptors.add(new ColumnFamilyDescriptor(cfName.getBytes()));
+        }
+
+        List<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>();
+        DBOptions options = new DBOptions()
+                .setCreateIfMissing(true)
+                .setCreateMissingColumnFamilies(true);
+
+        try (RocksDB db = RocksDB.open(options, dbPath.toString(), columnFamilyDescriptors, columnFamilyHandles)) {
+            columnFamilyHandles.forEach(ColumnFamilyHandle::close);
+            log.info("Created new blockchain database at {}", dbPath);
+        } finally {
+            options.close();
+        }
+
+        return new RocksDbWritableBlockchainDatabase(dbPath, networkParameters);
+    }
+
+    @Override
+    public void putBlockHeader(int height, Block block) throws RocksDBException {
+        // cloneAsHeader() drops the transactions so we serialize just the 80 byte header as the key
+        byte[] key = block.cloneAsHeader().serialize();
+        writeBatch.put(headersCF, key, BlockchainSchema.emptyValue());
+        headersByHeight.put(height, block);
+    }
+
+    @Override
+    public void updateChainTip(int height, Sha256Hash hash) throws RocksDBException {
+        writeBatch.put(headersCF, BlockchainSchema.Keys.CHAIN_TIP, reverseBytes(hash.getBytes()));
+    }
+
+    @Override
+    public void putTransactionHeight(Sha256Hash txid, int height) throws RocksDBException {
+        writeBatch.put(txidCF, BlockchainSchema.txidKey(txid), BlockchainSchema.encodeHeight(height));
+    }
+
+    @Override
+    public void putFunding(byte[] scriptHashPrefix, int height, byte[] txidPrefix, short vout) throws RocksDBException {
+        if (scriptHashPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Script hash prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        if (txidPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Txid prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        byte[] key = BlockchainSchema.fundingKey(scriptHashPrefix, height);
+        writeBatch.put(fundingCF, key, BlockchainSchema.emptyValue());
+    }
+
+    @Override
+    public void putSpending(byte[] txidPrefix, short vout, int height, byte[] spendingTxidPrefix, int vin) throws RocksDBException {
+        if (txidPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Txid prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        if (spendingTxidPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Spending txid prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        byte[] key = BlockchainSchema.spendingKey(txidPrefix, vout, height);
+        writeBatch.put(spendingCF, key, BlockchainSchema.emptyValue());
+    }
+
+    @Override
+    public void putConfig(String key, byte[] value) throws RocksDBException {
+        writeBatch.put(configCF, key.getBytes(), value);
+    }
+
+    @Override
+    public void deleteBlockHeader(int height) throws RocksDBException {
+        // need the block to rebuild the header key
+        Block block = headersByHeight.get(height);
+        if (block != null) {
+            writeBatch.delete(headersCF, block.cloneAsHeader().serialize());
+            headersByHeight.remove(height);
+        }
+    }
+
+    @Override
+    public void deleteTransactionHeight(Sha256Hash txid) throws RocksDBException {
+        writeBatch.delete(txidCF, BlockchainSchema.txidKey(txid));
+    }
+
+    @Override
+    public void deleteFunding(byte[] scriptHashPrefix, int height, byte[] txidPrefix, short vout) throws RocksDBException {
+        if (scriptHashPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Script hash prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        writeBatch.delete(fundingCF, BlockchainSchema.fundingKey(scriptHashPrefix, height));
+    }
+
+    @Override
+    public void deleteSpending(byte[] txidPrefix, short vout, int height, byte[] spendingTxidPrefix, int vin) throws RocksDBException {
+        if (txidPrefix.length != BlockchainSchema.PREFIX_LENGTH) {
+            throw new IllegalArgumentException("Txid prefix must be " + BlockchainSchema.PREFIX_LENGTH + " bytes");
+        }
+        writeBatch.delete(spendingCF, BlockchainSchema.spendingKey(txidPrefix, vout, height));
+    }
+
+    @Override
+    public void flush() throws RocksDBException {
+        db.write(writeOptions, writeBatch);
+        writeBatch.clear();
+        log.debug("Flushed write batch to database");
+    }
+
+    @Override
+    public void close() {
+        try {
+            // flush whatever is still pending so we don't silently lose writes
+            if (writeBatch.count() > 0) {
+                log.warn("Closing database with {} pending writes - flushing", writeBatch.count());
+                flush();
+            }
+        } catch (RocksDBException e) {
+            log.error("Error flushing pending writes on close", e);
+        }
+
+        log.info("Closing writable blockchain database");
+        writeBatch.close();
+        writeOptions.close();
+        super.close();
+    }
+}

--- a/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/writer/WritableBlockchainDatabase.java
+++ b/cj-btc-rocksdb/src/main/java/org/consensusj/bitcoin/rocksdb/writer/WritableBlockchainDatabase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.writer;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Block;
+import org.consensusj.bitcoin.rocksdb.reader.BlockchainDatabase;
+
+/**
+ * Adds write operations to {@link BlockchainDatabase}. Everything is staged in a RocksDB WriteBatch
+ * and only applied on {@link #flush()}, so a batch of puts/deletes lands atomically.
+ *
+ * The delete* methods exist mainly for reorg handling. All the *Prefix byte[] args are 8 bytes.
+ */
+public interface WritableBlockchainDatabase extends BlockchainDatabase {
+
+    void putBlockHeader(int height, Block block) throws Exception;
+
+    void updateChainTip(int height, Sha256Hash hash) throws Exception;
+
+    void putTransactionHeight(Sha256Hash txid, int height) throws Exception;
+
+    void putFunding(byte[] scriptHashPrefix, int height, byte[] txidPrefix, short vout) throws Exception;
+
+    void putSpending(byte[] txidPrefix, short vout, int height, byte[] spendingTxidPrefix, int vin) throws Exception;
+
+    void putConfig(String key, byte[] value) throws Exception;
+
+    void deleteBlockHeader(int height) throws Exception;
+
+    void deleteTransactionHeight(Sha256Hash txid) throws Exception;
+
+    void deleteFunding(byte[] scriptHashPrefix, int height, byte[] txidPrefix, short vout) throws Exception;
+
+    void deleteSpending(byte[] txidPrefix, short vout, int height, byte[] spendingTxidPrefix, int vin) throws Exception;
+
+    /** Applies all batched writes to disk. */
+    void flush() throws Exception;
+}

--- a/cj-btc-rocksdb/src/test/java/org/consensusj/bitcoin/rocksdb/integration/BlockchainDatabaseIntegrationTest.java
+++ b/cj-btc-rocksdb/src/test/java/org/consensusj/bitcoin/rocksdb/integration/BlockchainDatabaseIntegrationTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.integration;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.RegTestParams;
+import org.consensusj.bitcoin.rocksdb.reader.BlockchainDatabase;
+import org.consensusj.bitcoin.rocksdb.reader.RocksDbBlockchainDatabase;
+import org.consensusj.bitcoin.rocksdb.schema.BlockchainSchema;
+import org.consensusj.bitcoin.rocksdb.writer.RocksDbWritableBlockchainDatabase;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Round-trips data through the writer and back out the reader against a real temp RocksDB, to make
+ * sure the two stay compatible.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Blockchain Database Integration Tests")
+class BlockchainDatabaseIntegrationTest {
+
+    private Path tempDbPath;
+    private NetworkParameters params;
+    private Block genesisBlock;
+    private Block block1;
+    private Block block2;
+
+    @BeforeAll
+    void setup() throws Exception {
+        tempDbPath = Files.createTempDirectory("test-blockchain-db-");
+        params = RegTestParams.get();
+
+        genesisBlock = params.getGenesisBlock();
+        block1 = createNextBlock(genesisBlock, 1);
+        block2 = createNextBlock(block1, 2);
+    }
+
+    @AfterAll
+    void cleanup() throws IOException {
+        if (tempDbPath != null && Files.exists(tempDbPath)) {
+            Files.walk(tempDbPath)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            System.err.println("Failed to delete: " + path);
+                        }
+                    });
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Should create database and write genesis block")
+    void testWriteGenesisBlock() throws Exception {
+        try (var writer = RocksDbWritableBlockchainDatabase.create(tempDbPath, params)) {
+            assertTrue(writer.isOpen(), "Database should be open after creation");
+            writer.putBlockHeader(0, genesisBlock);
+            writer.updateChainTip(0, genesisBlock.getHash());
+            writer.flush();
+        }
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Should read back genesis block")
+    void testReadGenesisBlock() throws Exception {
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            assertTrue(reader.isOpen(), "Database should be open");
+
+            Optional<Integer> tipHeight = reader.getChainTipHeight();
+            assertTrue(tipHeight.isPresent(), "Chain tip height should be present");
+            assertEquals(0, tipHeight.get(), "Chain tip should be at height 0");
+
+            Optional<Sha256Hash> tipHash = reader.getChainTipHash();
+            assertTrue(tipHash.isPresent(), "Chain tip hash should be present");
+            assertEquals(genesisBlock.getHash(), tipHash.get(), "Chain tip hash should match genesis");
+
+            Optional<Block> readGenesis = reader.getBlockHeader(0);
+            assertTrue(readGenesis.isPresent(), "Genesis block should be readable");
+            assertEquals(genesisBlock.getHash(), readGenesis.get().getHash(), "Genesis block hash should match");
+        }
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Should write multiple blocks and build chain")
+    void testWriteMultipleBlocks() throws Exception {
+        try (var writer = new RocksDbWritableBlockchainDatabase(tempDbPath, params)) {
+            writer.putBlockHeader(1, block1);
+            writer.putBlockHeader(2, block2);
+            writer.updateChainTip(2, block2.getHash());
+            writer.flush();
+        }
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Should read back entire chain and verify consistency")
+    void testReadMultipleBlocks() throws Exception {
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            Optional<Integer> tipHeight = reader.getChainTipHeight();
+            assertTrue(tipHeight.isPresent(), "Chain tip height should be present");
+            assertEquals(2, tipHeight.get(), "Chain tip should be at height 2");
+
+            Optional<Sha256Hash> tipHash = reader.getChainTipHash();
+            assertTrue(tipHash.isPresent(), "Chain tip hash should be present");
+            assertEquals(block2.getHash(), tipHash.get(), "Chain tip should be block 2");
+
+            Optional<Block> readGenesis = reader.getBlockHeader(0);
+            Optional<Block> readBlock1 = reader.getBlockHeader(1);
+            Optional<Block> readBlock2 = reader.getBlockHeader(2);
+
+            assertTrue(readGenesis.isPresent(), "Genesis should be readable");
+            assertTrue(readBlock1.isPresent(), "Block 1 should be readable");
+            assertTrue(readBlock2.isPresent(), "Block 2 should be readable");
+
+            assertEquals(genesisBlock.getHash(), readGenesis.get().getHash(), "Genesis hash should match");
+            assertEquals(block1.getHash(), readBlock1.get().getHash(), "Block 1 hash should match");
+            assertEquals(block2.getHash(), readBlock2.get().getHash(), "Block 2 hash should match");
+
+            // the prevBlockHash links are what loadHeaders() walks, so check they survived the round trip
+            assertEquals(genesisBlock.getHash(), readBlock1.get().getPrevBlockHash(), "Block 1 should link to genesis");
+            assertEquals(block1.getHash(), readBlock2.get().getPrevBlockHash(), "Block 2 should link to block 1");
+        }
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Should write and read transaction heights")
+    void testTransactionIndexing() throws Exception {
+        // the index keys on the first 8 bytes, so these txids have to differ in there leading bytes
+        Sha256Hash tx1 = Sha256Hash.wrap("1100000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash tx2 = Sha256Hash.wrap("2200000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash tx3 = Sha256Hash.wrap("3300000000000000000000000000000000000000000000000000000000000000");
+
+        try (var writer = new RocksDbWritableBlockchainDatabase(tempDbPath, params)) {
+            writer.putTransactionHeight(tx1, 0);
+            writer.putTransactionHeight(tx2, 1);
+            writer.putTransactionHeight(tx3, 2);
+            writer.flush();
+        }
+
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            Optional<Integer> height1 = reader.getTransactionHeight(tx1);
+            Optional<Integer> height2 = reader.getTransactionHeight(tx2);
+            Optional<Integer> height3 = reader.getTransactionHeight(tx3);
+
+            assertTrue(height1.isPresent(), "Transaction 1 height should be present");
+            assertTrue(height2.isPresent(), "Transaction 2 height should be present");
+            assertTrue(height3.isPresent(), "Transaction 3 height should be present");
+
+            assertEquals(0, height1.get(), "Transaction 1 should be in genesis block");
+            assertEquals(1, height2.get(), "Transaction 2 should be in block 1");
+            assertEquals(2, height3.get(), "Transaction 3 should be in block 2");
+        }
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Should write and read funding indices (key-only storage)")
+    void testFundingIndex() throws Exception {
+        byte[] scriptHashPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        byte[] txidPrefix = new byte[]{10, 11, 12, 13, 14, 15, 16, 17};
+        short vout = 0;
+
+        try (var writer = new RocksDbWritableBlockchainDatabase(tempDbPath, params)) {
+            writer.putFunding(scriptHashPrefix, 0, txidPrefix, vout);
+            writer.putFunding(scriptHashPrefix, 1, txidPrefix, (short) 1);
+            writer.putFunding(scriptHashPrefix, 2, txidPrefix, (short) 2);
+            writer.flush();
+        }
+
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            List<Integer> heights = reader.getFundingHeights(scriptHashPrefix);
+
+            assertNotNull(heights, "Funding heights list should not be null");
+            assertEquals(3, heights.size(), "Should have 3 funding entries");
+            assertTrue(heights.contains(0), "Should have funding at height 0");
+            assertTrue(heights.contains(1), "Should have funding at height 1");
+            assertTrue(heights.contains(2), "Should have funding at height 2");
+        }
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Should write and read spending indices (key-only storage)")
+    void testSpendingIndex() throws Exception {
+        // reader derives the lookup prefix from fundingTxid, so derive the written prefix the same way
+        Sha256Hash fundingTxid = Sha256Hash.wrap("aa00000000000000000000000000000000000000000000000000000000000000");
+        byte[] fundingTxidPrefix = BlockchainSchema.txidKey(fundingTxid);
+        byte[] spendingTxidPrefix = new byte[]{0, 0, 0, 0, 0, 0, 0, 2};
+        short vout = 0;
+        int vin = 0;
+
+        try (var writer = new RocksDbWritableBlockchainDatabase(tempDbPath, params)) {
+            writer.putSpending(fundingTxidPrefix, vout, 1, spendingTxidPrefix, vin);
+            writer.flush();
+        }
+
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            List<Integer> heights = reader.getSpendingHeights(fundingTxid, vout);
+
+            assertNotNull(heights, "Spending heights list should not be null");
+            assertEquals(1, heights.size(), "Should have 1 spending entry");
+            assertEquals(1, heights.get(0), "Spending should be at height 1");
+        }
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("Should get database statistics")
+    void testDatabaseStats() throws Exception {
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            BlockchainDatabase.DatabaseStats stats = reader.getStats();
+
+            assertNotNull(stats, "Stats should not be null");
+            assertTrue(stats.fundingKeys() >= 3, "Should have at least 3 funding keys");
+            assertTrue(stats.spendingKeys() >= 1, "Should have at least 1 spending key");
+            assertTrue(stats.txidKeys() >= 3, "Should have at least 3 txid keys");
+            assertTrue(stats.headerKeys() >= 3, "Should have at least 3 header keys");
+        }
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("Should handle non-existent data gracefully")
+    void testNonExistentData() throws Exception {
+        try (var reader = new RocksDbBlockchainDatabase(tempDbPath, params)) {
+            Optional<Block> nonExistent = reader.getBlockHeader(100);
+            assertFalse(nonExistent.isPresent(), "Non-existent block should return empty");
+
+            Sha256Hash nonExistentTx = Sha256Hash.wrap("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            Optional<Integer> txHeight = reader.getTransactionHeight(nonExistentTx);
+            assertFalse(txHeight.isPresent(), "Non-existent transaction should return empty");
+
+            byte[] nonExistentScript = new byte[]{99, 99, 99, 99, 99, 99, 99, 99};
+            List<Integer> fundingHeights = reader.getFundingHeights(nonExistentScript);
+            assertTrue(fundingHeights.isEmpty(), "Non-existent script should return empty list");
+        }
+    }
+
+    // a bare header on top of prevBlock - merkle root is zeroed since we don't care about txs here
+    private Block createNextBlock(Block prevBlock, long timeSeconds) {
+        return new Block(
+                2L,
+                prevBlock.getHash(),
+                Sha256Hash.ZERO_HASH,
+                timeSeconds,
+                prevBlock.getDifficultyTarget(),
+                0L,
+                java.util.Collections.emptyList()
+        );
+    }
+}

--- a/cj-btc-rocksdb/src/test/java/org/consensusj/bitcoin/rocksdb/schema/BlockchainSchemaTest.java
+++ b/cj-btc-rocksdb/src/test/java/org/consensusj/bitcoin/rocksdb/schema/BlockchainSchemaTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2014-2026 ConsensusJ Developers.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.consensusj.bitcoin.rocksdb.schema;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Checks the key encodings - byte lengths, round-tripping and the input validation.
+ */
+@DisplayName("BlockchainSchema Tests")
+class BlockchainSchemaTest {
+
+    @Test
+    @DisplayName("Funding key should be 12 bytes (8-byte prefix + 4-byte height)")
+    void testFundingKeyLength() {
+        byte[] scriptHashPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        int height = 700000;
+
+        byte[] fundingKey = BlockchainSchema.fundingKey(scriptHashPrefix, height);
+
+        assertEquals(12, fundingKey.length, "Funding key must be exactly 12 bytes");
+    }
+
+    @Test
+    @DisplayName("Funding key should contain script hash prefix and height")
+    void testFundingKeyComponents() {
+        byte[] scriptHashPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        int height = 700000;
+
+        byte[] fundingKey = BlockchainSchema.fundingKey(scriptHashPrefix, height);
+
+        byte[] extractedPrefix = BlockchainSchema.extractScriptHashPrefix(fundingKey);
+        int extractedHeight = BlockchainSchema.extractFundingHeight(fundingKey);
+
+        assertArrayEquals(scriptHashPrefix, extractedPrefix, "Script hash prefix should match");
+        assertEquals(height, extractedHeight, "Height should match");
+    }
+
+    @Test
+    @DisplayName("Spending key should be 14 bytes (8-byte txid + 2-byte vout + 4-byte height)")
+    void testSpendingKeyLength() {
+        byte[] txidPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        short vout = 0;
+        int height = 700000;
+
+        byte[] spendingKey = BlockchainSchema.spendingKey(txidPrefix, vout, height);
+
+        assertEquals(14, spendingKey.length, "Spending key must be exactly 14 bytes");
+    }
+
+    @Test
+    @DisplayName("Spending key should contain txid prefix, vout, and height")
+    void testSpendingKeyComponents() {
+        byte[] txidPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        short vout = 5;
+        int height = 700000;
+
+        byte[] spendingKey = BlockchainSchema.spendingKey(txidPrefix, vout, height);
+
+        byte[] extractedTxidPrefix = BlockchainSchema.extractTxidPrefix(spendingKey);
+        short extractedVout = BlockchainSchema.extractVout(spendingKey);
+        int extractedHeight = BlockchainSchema.extractSpendingHeight(spendingKey);
+
+        assertArrayEquals(txidPrefix, extractedTxidPrefix, "Txid prefix should match");
+        assertEquals(vout, extractedVout, "Vout should match");
+        assertEquals(height, extractedHeight, "Height should match");
+    }
+
+    @Test
+    @DisplayName("Txid key should be 8 bytes (8-byte prefix)")
+    void testTxidKeyLength() {
+        Sha256Hash txid = Sha256Hash.wrap("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+        byte[] txidKey = BlockchainSchema.txidKey(txid);
+
+        assertEquals(8, txidKey.length, "Txid key must be exactly 8 bytes");
+    }
+
+    @Test
+    @DisplayName("Empty value should be zero bytes (electrs key-only storage)")
+    void testEmptyValue() {
+        byte[] emptyValue = BlockchainSchema.emptyValue();
+
+        assertNotNull(emptyValue, "Empty value should not be null");
+        assertEquals(0, emptyValue.length, "Empty value must have zero length for electrs compatibility");
+    }
+
+    @Test
+    @DisplayName("Height encoding should be 4 bytes")
+    void testHeightEncoding() {
+        int height = 700000;
+
+        byte[] encoded = BlockchainSchema.encodeHeight(height);
+
+        assertEquals(4, encoded.length, "Encoded height must be 4 bytes");
+
+        int decoded = BlockchainSchema.decodeHeight(encoded);
+        assertEquals(height, decoded, "Decoded height should match original");
+    }
+
+    @Test
+    @DisplayName("Should reject invalid script hash prefix length")
+    void testInvalidScriptHashPrefixLength() {
+        byte[] invalidPrefix = new byte[]{1, 2, 3, 4};
+        int height = 700000;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BlockchainSchema.fundingKey(invalidPrefix, height),
+                "Should reject script hash prefix that is not 8 bytes");
+    }
+
+    @Test
+    @DisplayName("Should reject invalid txid prefix length in spending key")
+    void testInvalidTxidPrefixLengthInSpendingKey() {
+        byte[] invalidPrefix = new byte[]{1, 2, 3, 4};
+        short vout = 0;
+        int height = 700000;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> BlockchainSchema.spendingKey(invalidPrefix, vout, height),
+                "Should reject txid prefix that is not 8 bytes");
+    }
+
+    @Test
+    @DisplayName("Column families array should contain all required CFs")
+    void testColumnFamiliesArray() {
+        String[] cfs = BlockchainSchema.ColumnFamilies.ALL;
+
+        assertEquals(6, cfs.length, "Should have exactly 6 column families");
+
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.DEFAULT), "Should contain DEFAULT");
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.FUNDING), "Should contain FUNDING");
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.SPENDING), "Should contain SPENDING");
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.TXID), "Should contain TXID");
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.HEADERS), "Should contain HEADERS");
+        assertTrue(contains(cfs, BlockchainSchema.ColumnFamilies.CONFIG), "Should contain CONFIG");
+    }
+
+    @Test
+    @DisplayName("Prefix length should be 8 bytes")
+    void testPrefixLength() {
+        assertEquals(8, BlockchainSchema.PREFIX_LENGTH,
+                "Prefix length must be 8 bytes for electrs compatibility");
+    }
+
+    @Test
+    @DisplayName("Header size should be 80 bytes")
+    void testHeaderSize() {
+        assertEquals(80, BlockchainSchema.HEADER_SIZE,
+                "Bitcoin block headers are always 80 bytes");
+    }
+
+    @Test
+    @DisplayName("Special keys should be defined correctly")
+    void testSpecialKeys() {
+        assertEquals(1, BlockchainSchema.Keys.CHAIN_TIP.length,
+                "Chain tip key should be 1 byte");
+        assertEquals('T', BlockchainSchema.Keys.CHAIN_TIP[0],
+                "Chain tip key should be 'T'");
+
+        assertEquals(1, BlockchainSchema.Keys.CONFIG.length,
+                "Config key should be 1 byte");
+        assertEquals('C', BlockchainSchema.Keys.CONFIG[0],
+                "Config key should be 'C'");
+    }
+
+    @Test
+    @DisplayName("Height should support full range of int values")
+    void testHeightRange() {
+        int[] testHeights = {0, 1, 700000, Integer.MAX_VALUE};
+
+        for (int height : testHeights) {
+            byte[] encoded = BlockchainSchema.encodeHeight(height);
+            int decoded = BlockchainSchema.decodeHeight(encoded);
+            assertEquals(height, decoded, "Height " + height + " should round-trip correctly");
+        }
+    }
+
+    @Test
+    @DisplayName("Vout should support full range of short values")
+    void testVoutRange() {
+        byte[] txidPrefix = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
+        int height = 700000;
+
+        short[] testVouts = {0, 1, 100, Short.MAX_VALUE};
+
+        for (short vout : testVouts) {
+            byte[] key = BlockchainSchema.spendingKey(txidPrefix, vout, height);
+            short extractedVout = BlockchainSchema.extractVout(key);
+            assertEquals(vout, extractedVout, "Vout " + vout + " should round-trip correctly");
+        }
+    }
+
+    private boolean contains(String[] array, String value) {
+        for (String s : array) {
+            if (s.equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@
 consensusjVersion = 0.7.0-DEV
 
 bitcoinjVersion = 0.17.1
+rocksdbVersion = 8.11.3
 rxJavaVersion = 3.1.12
 groovyVersion = 4.0.30
 errorProneVersion = 2.48.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,3 +39,4 @@ if (JavaVersion.current().compareTo(JavaVersion.VERSION_21) < 0) {
     include 'consensusj-jsonrpc-cli'            // JSON-RPC CLI library
     include 'consensusj-jrpc'                   // `jrpc` CLI Tool
     include 'cj-btc-cli'                        // Bitcoin JSON-RPC CLI
+    include 'cj-btc-rocksdb'                    // RocksDB-based blockchain database


### PR DESCRIPTION
New module providing a reader and writer over a RocksDB store of Bitcoin blockchain index data.
- `BlockchainDatabase` / `WritableBlockchainDatabase` interfaces and a shared AbstractRocksDbBlockchainDatabase base holding the read implementation
- BlockchainSchema for the key encodings and column family layout
- Integration and schema unit tests