### PR TITLE
javadoc.gradle: re-enable link to bitcoinj 0.17.1 Javadoc

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -32,7 +32,7 @@ List<CharSequence> javaDocLinks() {
             "https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jacksonVersion}"
     ]
 
-    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("rc") && !bitcoinjVersion.contains("SNAPSHOT") && !bitcoinjVersion.contains("0.17.1")) {
+    if (!bitcoinjVersion.contains("beta") && !bitcoinjVersion.contains("alpha") && !bitcoinjVersion.contains("rc") && !bitcoinjVersion.contains("SNAPSHOT")) {
         javaDocLinks << "https://bitcoinj.org/javadoc/${bitcoinjVersion}/"
     }
     return Collections.unmodifiableList(javaDocLinks)


### PR DESCRIPTION
We released ConsensusJ 0.7.0-beta3 before the bitcoin 0.17.1 Javadoc was published and put in a special case to disable the link. This commit removes the special case.

Closes #338 