### PR TITLE
GHA build.yml: Use setup-java in place of setup-graalvm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,16 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v6
-      - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+      - name: Set up Java (GraalVM)
+        uses: actions/setup-java@v5
         with:
-          java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          java-version: ${{ matrix.java-version }}
           cache: 'gradle'
+      # Unlike `graalvm/setup-graalvm`, `actions/setup-java` doesn't set `GRAALVM_HOME` so we'll do it explicitly.
+      # The cj-btc-cli and consensusj-jrpc modules require `GRAALVM_HOME` to be set.
+      - name: Set GRAALVM_HOME
+        run: echo "GRAALVM_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
       - name: Build with Gradle
         run: ./gradlew consensusj-jrpc-echod:nativeTest nativeCompile --scan --info --stacktrace
       - name: Upload jrpc tool as artifact


### PR DESCRIPTION
As of [v5.4.0](https://github.com/actions/setup-java/releases/tag/v5.4.0), setup-java can install `graalvm-community`.