### PR TITLE
{cj-btc-cli,consensusj-rpc}/build.gradle: fallback from GRAALVM_HOME to JAVA_HOME

### DIFF
--- a/cj-btc-cli/build.gradle
+++ b/cj-btc-cli/build.gradle
@@ -72,7 +72,7 @@ jar {
 tasks.register('nativeCompile', Exec) {
     dependsOn jar
     workingDir = projectDir
-    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    executable = "${System.env.GRAALVM_HOME ?: System.env.JAVA_HOME}/bin/native-image"
     args = ['--verbose',
             '--no-fallback',
             '-cp', "${-> configurations.nativeToolImplementation.asPath}", // Lazy configuration resolution

--- a/consensusj-jrpc/build.gradle
+++ b/consensusj-jrpc/build.gradle
@@ -72,7 +72,7 @@ jar {
 tasks.register('nativeCompile', Exec) {
     dependsOn jar
     workingDir = projectDir
-    executable = "${System.env.GRAALVM_HOME}/bin/native-image"
+    executable = "${System.env.GRAALVM_HOME ?: System.env.JAVA_HOME}/bin/native-image"
     args = [
         '--verbose',
         '--no-fallback',


### PR DESCRIPTION
When providing the path to `native-image` uses `JAVA_HOME` if `GRAALVM_HOME` is not defined.