### PR TITLE
Gradle build: remove byte-buddy and objenesis from dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,9 +128,6 @@ subprojects {
                         implementation(libs.spock.core) {
                             exclude module: "groovy-all"
                         }
-
-                        runtimeOnly libs.bytebuddy   // Lets Spock mock classes (in addition to interfaces)
-                        runtimeOnly libs.objenesis   // Lets Spock mock classes with constructor arguments
                     }
                 }
             }

--- a/cj-btc-cli/build.gradle
+++ b/cj-btc-cli/build.gradle
@@ -36,11 +36,6 @@ testing {
                 implementation(libs.spock.core) {
                     exclude module: "groovy-all"
                 }
-
-                runtimeOnly libs.bytebuddy
-                // allows Spock to mock classes (in addition to interfaces)
-                runtimeOnly libs.objenesis
-                // Allow Spock to mock classes with constructor arguments
                 runtimeOnly libs.slf4j.jdk14   // Runtime implementation of slf4j
             }
 

--- a/cj-btc-jsonrpc-integ-test/build.gradle
+++ b/cj-btc-jsonrpc-integ-test/build.gradle
@@ -19,9 +19,6 @@ testing {
                 implementation (libs.groovy.json) {
                     transitive = false
                 }
-
-                runtimeOnly libs.bytebuddy       // Allows Spock to mock classes (in addition to interfaces)
-                runtimeOnly libs.objenesis           // Allows Spock to mock classes with constructor arguments
                 runtimeOnly libs.slf4j.jdk14 // Runtime implementation of slf4j
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,6 @@ jackson = "2.21.5"
 micronaut = "4.10.17"
 javamoneyApi = "1.1"
 moneta = "1.4.4"
-bytebuddy = "1.18.10"
-objenesis = "3.5"
 nashorn = "15.7"
 jeromq = "0.6.0"
 jakartaInject = "2.0.1"
@@ -46,8 +44,6 @@ micronaut-platform       = { module = "io.micronaut.platform:micronaut-platform"
 javamoney-api            = { module = "javax.money:money-api",                              version.ref = "javamoneyApi" }
 moneta-core              = { module = "org.javamoney.moneta:moneta-core",                   version.ref = "moneta" }
 moneta-convert           = { module = "org.javamoney.moneta:moneta-convert",               version.ref = "moneta" }
-bytebuddy                = { module = "net.bytebuddy:byte-buddy",                           version.ref = "bytebuddy" }
-objenesis                = { module = "org.objenesis:objenesis",                            version.ref = "objenesis" }
 nashorn-core             = { module = "org.openjdk.nashorn:nashorn-core",                   version.ref = "nashorn" }
 jeromq                   = { module = "org.zeromq:jeromq",                                  version.ref = "jeromq" }
 jakarta-inject-api       = { module = "jakarta.inject:jakarta.inject-api",                  version.ref = "jakartaInject" }

--- a/nix-deps.json
+++ b/nix-deps.json
@@ -1373,13 +1373,6 @@
    "jar": "sha256-PtpqE3m1e9zZLx7dOaR7lF/qSByzh0QzW+4q3yGOSxc=",
    "pom": "sha256-kdeJ4O7Yp/2KirQ+dUhX4+6xXDOykOV4ZIOUooQLbRQ="
   },
-  "net/bytebuddy#byte-buddy-parent/1.18.10": {
-   "pom": "sha256-jAWWPJOikMbWVmmUOGVE1cfR9FZ6tAcOqQVSDh/ed7w="
-  },
-  "net/bytebuddy#byte-buddy/1.18.10": {
-   "jar": "sha256-izH06oBq+qkAtnv/2EmHYNH2VGT0wup4zb2i8+YziYs=",
-   "pom": "sha256-IxyDtIjJZb5WWnT6D43SvHDP98uEfMl93VaypwCgz2I="
-  },
   "net/java#jvnet-parent/3": {
    "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
   },
@@ -1844,13 +1837,6 @@
   },
   "org/knowm/xchange#xchange-parent/5.2.2": {
    "pom": "sha256-9IlDTNYSVQrCvCxruci/9GXlxdiRvU9boXJ0s0mNU6w="
-  },
-  "org/objenesis#objenesis-parent/3.5": {
-   "pom": "sha256-up+Z3fcpbWwF5EKdhEN52gFxrVboJ2RNdtVHu3PBz0o="
-  },
-  "org/objenesis#objenesis/3.5": {
-   "jar": "sha256-b1q9Qs8+vA8r2uc9vFeCD8Shy4kwSShB4p6an53MhuA=",
-   "pom": "sha256-BSjmTxaXywaZOnlRcXd8bSSkJcmuDdKY7GQBhO30Zag="
   },
   "org/openjdk/nashorn#nashorn-core/15.7": {
    "jar": "sha256-Pyti5VtUWLouigzEWZqjq+gbFCLjHDi7gpSnCWzu5vI=",


### PR DESCRIPTION
These runtimeOnly dependencies are provided to enable Gradle to:

* mock classes in addition to interfaces (byte-buddy)
* mock classes with constructor arguments (objenesis)

We have not been using either of these features, but thought we might do so in the future. Given that we are migrating away from Spock to plain JUnit for GraalVM native testing, we will probably never use these features.

Leaving them in the build.gradle classpath means we need to update them as new versions are released. Let's remove them. We can always add them back if we decide we will actually be using them.